### PR TITLE
feat: enable App Sandbox for App Store compliance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,10 +33,16 @@ npm start  # Runs on http://127.0.0.1:3456
 ## Architecture
 
 ### Data Flow
-1. **ccusage Integration**: Fetches usage data via local server (preferred) or direct npx execution
+1. **ccusage Integration**: Fetches usage data via local server (required when App Sandbox is enabled)
 2. **Session-Based Monitoring**: Claude Code uses 5-hour session blocks with token limits
 3. **Real-Time Updates**: 5-minute auto-refresh with manual refresh option
 4. **MainActor Isolation**: SwiftUI views and UsageMonitor are @MainActor isolated
+
+### App Sandbox Support
+- **App Sandbox is enabled** for App Store distribution
+- When App Sandbox is enabled, the local server (http://127.0.0.1:3456) is **required**
+- Direct command execution (npx) is not possible with App Sandbox
+- Network entitlements allow localhost connections
 
 ### Key Components
 

--- a/ClaudeUsageMonitor.entitlements
+++ b/ClaudeUsageMonitor.entitlements
@@ -3,10 +3,12 @@
 <plist version="1.0">
 <dict>
     <key>com.apple.security.app-sandbox</key>
-    <false/>
+    <true/>
     <key>com.apple.security.network.client</key>
     <true/>
     <key>com.apple.security.network.server</key>
+    <true/>
+    <key>com.apple.security.inherit</key>
     <true/>
 </dict>
 </plist>

--- a/Info.plist
+++ b/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleIdentifier</key>
-    <string>com.claude.usage.monitor</string>
+    <string>com.k9i.claude-usage-monitor</string>
     <key>CFBundleName</key>
     <string>Claude Usage Monitor</string>
     <key>CFBundleDisplayName</key>

--- a/Sources/ClaudeUsageMonitor/Localization.swift
+++ b/Sources/ClaudeUsageMonitor/Localization.swift
@@ -111,6 +111,7 @@ struct L10n {
         static var dataFetchFailed: String { "error.dataFetchFailed".localized }
         static var networkError: String { "error.networkError".localized }
         static var unknown: String { "error.unknown".localized }
+        static var serverNotRunning: String { "error.serverNotRunning".localized }
     }
     
     struct Settings {

--- a/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
@@ -67,6 +67,7 @@
 "error.dataFetchFailed" = "Failed to fetch data";
 "error.networkError" = "Network error";
 "error.unknown" = "Unknown error";
+"error.serverNotRunning" = "Local server is not running. Please start the server with 'npm start' in the server directory.";
 
 // Time format
 "time.hoursMinutes" = "%d hours %d minutes";

--- a/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
@@ -67,6 +67,7 @@
 "error.dataFetchFailed" = "データの取得に失敗しました";
 "error.networkError" = "ネットワークエラー";
 "error.unknown" = "不明なエラー";
+"error.serverNotRunning" = "ローカルサーバーが起動していません。serverディレクトリで'npm start'を実行してください。";
 
 // Time format
 "time.hoursMinutes" = "%d時間%d分";

--- a/Sources/ClaudeUsageMonitor/UsageMonitor.swift
+++ b/Sources/ClaudeUsageMonitor/UsageMonitor.swift
@@ -110,12 +110,21 @@ class UsageMonitor: ObservableObject, UsageMonitoring {
             error = ClaudeMonitorError.parsingError(decodingError.localizedDescription)
             print("Decoding error: \(decodingError)")
         } catch {
-            // Server not running or request failed, fall back to npx
-            print("Local server not available, falling back to npx command")
+            // Server not running or request failed
+            print("Local server not available: \(error.localizedDescription)")
+            self.error = ClaudeMonitorError.networkError(L10n.Error.serverNotRunning)
+            return
         }
         
-        // Fallback to npx command with better path handling
-        print("[DEBUG] Daily data: falling back to npx command")
+        // App Sandbox prevents direct command execution
+        // The following code only works when App Sandbox is disabled
+        guard ProcessInfo.processInfo.environment["APP_SANDBOX_CONTAINER_ID"] == nil else {
+            print("[DEBUG] App Sandbox is enabled - cannot execute external commands")
+            return
+        }
+        
+        // Fallback to npx command (only when App Sandbox is disabled)
+        print("[DEBUG] App Sandbox is disabled - falling back to npx command")
         do {
             let process = Process()
             
@@ -268,10 +277,17 @@ class UsageMonitor: ObservableObject, UsageMonitoring {
             }
         } catch {
             print("[DEBUG] Server connection failed: \(error.localizedDescription)")
+            self.error = ClaudeMonitorError.networkError(L10n.Error.serverNotRunning)
         }
         
-        // Fallback: Try multiple methods to run ccusage
-        print("[DEBUG] Falling back to direct ccusage execution")
+        // App Sandbox prevents direct command execution
+        guard ProcessInfo.processInfo.environment["APP_SANDBOX_CONTAINER_ID"] == nil else {
+            print("[DEBUG] App Sandbox is enabled - cannot execute external commands")
+            return
+        }
+        
+        // Fallback: Try multiple methods to run ccusage (only when App Sandbox is disabled)
+        print("[DEBUG] App Sandbox is disabled - falling back to direct ccusage execution")
         
         // Method 1: Try to find npx in common locations
         let npxSearchPaths = [

--- a/build-config/hardened-runtime.plist
+++ b/build-config/hardened-runtime.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Allow DYLD environment variables -->
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <!-- Allow unsigned executable memory -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <false/>
+    <!-- Disable library validation -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <false/>
+    <!-- Disable executable memory protection -->
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <false/>
+    <!-- Allow JIT -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <false/>
+</dict>
+</plist>

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Build script for ClaudeUsageMonitor with App Sandbox and Hardened Runtime
+# This script builds the app with proper code signing for App Store distribution
+
+set -e
+
+# Configuration
+APP_NAME="ClaudeUsageMonitor"
+BUNDLE_ID="com.k9i.claude-usage-monitor"  # Replace with your bundle ID
+BUILD_DIR=".build/release"
+APP_DIR="$APP_NAME.app"
+DEVELOPER_ID="Developer ID Application: Your Name (XXXXXXXXXX)"  # Replace with your Developer ID
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Building $APP_NAME for release...${NC}"
+
+# Clean previous builds
+echo -e "${YELLOW}Cleaning previous builds...${NC}"
+rm -rf "$BUILD_DIR"
+rm -rf "$APP_DIR"
+
+# Build in release mode
+echo -e "${YELLOW}Building with Swift...${NC}"
+swift build -c release
+
+# Create app bundle structure
+echo -e "${YELLOW}Creating app bundle...${NC}"
+mkdir -p "$APP_DIR/Contents/MacOS"
+mkdir -p "$APP_DIR/Contents/Resources"
+
+# Copy executable
+cp "$BUILD_DIR/$APP_NAME" "$APP_DIR/Contents/MacOS/"
+
+# Copy Info.plist
+cp Info.plist "$APP_DIR/Contents/"
+
+# Copy entitlements
+cp ClaudeUsageMonitor.entitlements "$APP_DIR/Contents/"
+
+# Sign the app with hardened runtime and entitlements
+echo -e "${YELLOW}Signing app with hardened runtime...${NC}"
+if [ -z "$SKIP_SIGNING" ]; then
+    codesign --force --deep --strict \
+        --options runtime \
+        --entitlements ClaudeUsageMonitor.entitlements \
+        --sign "$DEVELOPER_ID" \
+        "$APP_DIR"
+    
+    # Verify the signature
+    echo -e "${YELLOW}Verifying signature...${NC}"
+    codesign --verify --deep --strict --verbose=2 "$APP_DIR"
+    
+    # Check entitlements
+    echo -e "${YELLOW}Checking entitlements...${NC}"
+    codesign -d --entitlements - "$APP_DIR"
+else
+    echo -e "${YELLOW}Skipping code signing (SKIP_SIGNING is set)${NC}"
+fi
+
+echo -e "${GREEN}Build complete!${NC}"
+echo -e "${GREEN}App bundle created at: $APP_DIR${NC}"
+
+# Test App Sandbox
+echo -e "${YELLOW}Testing App Sandbox...${NC}"
+if [ -z "$SKIP_SIGNING" ]; then
+    # Check if app is sandboxed
+    if codesign -d --entitlements - "$APP_DIR" 2>/dev/null | grep -q "com.apple.security.app-sandbox.*true"; then
+        echo -e "${GREEN}✓ App Sandbox is enabled${NC}"
+    else
+        echo -e "${RED}✗ App Sandbox is NOT enabled${NC}"
+        exit 1
+    fi
+    
+    # Check if hardened runtime is enabled
+    if codesign --display --verbose "$APP_DIR" 2>&1 | grep -q "flags=.*runtime"; then
+        echo -e "${GREEN}✓ Hardened Runtime is enabled${NC}"
+    else
+        echo -e "${RED}✗ Hardened Runtime is NOT enabled${NC}"
+        exit 1
+    fi
+fi
+
+echo -e "${GREEN}All checks passed!${NC}"


### PR DESCRIPTION
## Summary
- Enabled App Sandbox in entitlements for App Store distribution
- Added Hardened Runtime configuration and release build script
- Updated bundle identifier to use k9i organization

## Changes
- **App Sandbox**: Enabled `com.apple.security.app-sandbox` in entitlements
- **Error Handling**: Added proper error messages when running in sandboxed environment
- **Build Script**: Created `scripts/build-release.sh` for release builds with code signing
- **Bundle ID**: Updated to `com.k9i.claude-usage-monitor`

## Technical Details
When App Sandbox is enabled, the app can only use the local server connection and cannot execute external commands directly. This is a requirement for App Store distribution.

## Test Plan
- [x] Build app with App Sandbox enabled
- [x] Verify app runs with local server
- [x] Verify appropriate error messages when server is not running
- [ ] Test on clean macOS environment
- [ ] Verify code signing with Developer ID

Related to #K9I-30

🤖 Generated with [Claude Code](https://claude.ai/code)