### PR TITLE
docs: add privacy policy for app distribution

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,99 @@
+# Privacy Policy
+
+*Last updated: June 24, 2025*
+
+## Overview
+
+Claude Code Monitor ("we", "our", or "the app") is committed to protecting your privacy. This Privacy Policy explains how our macOS application handles information.
+
+## Data Collection
+
+**We do not collect any personal data.**
+
+Claude Code Monitor operates entirely on your local machine and:
+- Does not collect, store, or transmit any personal information
+- Does not track usage analytics
+- Does not use cookies or similar tracking technologies
+- Does not share any data with third parties
+
+## Local Data Processing
+
+All data processing occurs locally on your device:
+- API usage data is fetched directly from Claude's servers to your machine
+- Usage history is stored only in your local browser's storage
+- No data leaves your device except for direct API calls to Claude
+
+## Third-Party Services
+
+The app interacts with:
+- **Claude API**: To fetch your usage data (requires your existing Claude authentication)
+- **ccusage CLI tool**: Used locally to retrieve usage information
+
+These interactions use your existing authentication and do not involve any data collection by our app.
+
+## Data Security
+
+Since we don't collect any data, there is no risk of data breaches from our servers. All data remains under your control on your local machine.
+
+## Children's Privacy
+
+Our app does not collect data from anyone, including children under 13.
+
+## Changes to This Policy
+
+We may update this Privacy Policy from time to time. Any changes will be reflected in the "Last updated" date above.
+
+## Contact
+
+If you have questions about this Privacy Policy, please create an issue on our [GitHub repository](https://github.com/K9i-0/ClaudeCodeMonitor/issues).
+
+---
+
+# プライバシーポリシー
+
+*最終更新日: 2025年6月24日*
+
+## 概要
+
+Claude Code Monitor（以下「本アプリ」）は、お客様のプライバシーを保護することをお約束します。このプライバシーポリシーは、本macOSアプリケーションが情報をどのように扱うかを説明します。
+
+## データ収集
+
+**本アプリは個人データを一切収集しません。**
+
+Claude Code Monitorは完全にローカルで動作し：
+- 個人情報の収集、保存、送信を行いません
+- 使用状況の分析を行いません
+- Cookieや類似の追跡技術を使用しません
+- 第三者とデータを共有しません
+
+## ローカルデータ処理
+
+すべてのデータ処理はお客様のデバイス上で行われます：
+- API使用状況データはClaudeのサーバーから直接お客様のマシンに取得されます
+- 使用履歴はお客様のローカルブラウザストレージにのみ保存されます
+- ClaudeへのAPI呼び出し以外、データがデバイスから送信されることはありません
+
+## サードパーティサービス
+
+本アプリは以下と連携します：
+- **Claude API**: 使用状況データの取得（既存のClaude認証が必要）
+- **ccusage CLIツール**: 使用状況情報の取得にローカルで使用
+
+これらの連携は既存の認証を使用し、本アプリによるデータ収集は行われません。
+
+## データセキュリティ
+
+本アプリはデータを収集しないため、サーバーからのデータ漏洩のリスクはありません。すべてのデータはお客様のローカルマシン上で管理されます。
+
+## 子供のプライバシー
+
+本アプリは13歳未満の子供を含む、誰からもデータを収集しません。
+
+## ポリシーの変更
+
+このプライバシーポリシーは随時更新される場合があります。変更は上記の「最終更新日」に反映されます。
+
+## お問い合わせ
+
+このプライバシーポリシーについてご質問がある場合は、[GitHubリポジトリ](https://github.com/K9i-0/ClaudeCodeMonitor/issues)でissueを作成してください。


### PR DESCRIPTION
## 概要
プライバシーポリシーを追加しました。

## 変更内容
- 英語/日本語のプライバシーポリシー作成
- データ収集なし、ローカル処理のみを明記
- App StoreとGitHub公開に必要な最小限の内容

## 関連Issue
- Linear: K9I-36 (ドキュメント整備)