### PR TITLE
docs: add screenshot placeholders and improve README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -59,8 +59,8 @@ macOSのメニューバーに常駐し、Claude Codeの使用状況をリアル�
 ### 1. リポジトリのクローン
 
 ```bash
-git clone https://github.com/K9i-0/ClaudeUsageMonitor.git
-cd ClaudeUsageMonitor
+git clone https://github.com/K9i-0/ClaudeCodeMonitor.git
+cd ClaudeCodeMonitor
 ```
 
 ### 2. Node.jsサーバーのセットアップ（推奨）
@@ -94,20 +94,50 @@ Xcodeで:
 swift build -c release
 
 # アプリバンドルの作成
-mkdir -p ClaudeUsageMonitor.app/Contents/MacOS
-mkdir -p ClaudeUsageMonitor.app/Contents/Resources
-cp .build/arm64-apple-macosx/release/ClaudeUsageMonitor ClaudeUsageMonitor.app/Contents/MacOS/
-cp Info.plist ClaudeUsageMonitor.app/Contents/
+mkdir -p ClaudeCodeMonitor.app/Contents/MacOS
+mkdir -p ClaudeCodeMonitor.app/Contents/Resources
+cp .build/arm64-apple-macosx/release/ClaudeCodeMonitor ClaudeCodeMonitor.app/Contents/MacOS/
+cp Info.plist ClaudeCodeMonitor.app/Contents/
 
 # アプリを起動
-open ClaudeUsageMonitor.app
+open ClaudeCodeMonitor.app
 ```
 
 ## 🖼️ スクリーンショット
 
-<p align="center">
-  <i>スクリーンショットは準備中です</i>
-</p>
+### メニューバーアイコン
+現在のセッション使用率をメニューバーに直接表示：
+- 🔵 青（0-50%）：安全な使用範囲
+- 🟠 オレンジ（50-75%）：中程度の使用
+- 🔴 赤（75%+）：高使用率警告
+
+![メニューバーアイコン](docs/images/menubar-icon.png)
+
+### 現在のセッション表示
+5時間セッションの詳細表示：
+- 大きくて読みやすい残りトークン数表示
+- 色分けされたプログレスバー
+- バーンレート計算（トークン/分）
+- 残り時間の推定
+
+![現在のセッション](docs/images/current-session.png)
+
+### 履歴表示
+時間経過による使用パターンの追跡：
+- セッション別の内訳
+- 日別使用量サマリ
+- モデル別の使用統計
+- コスト追跡（参考値）
+
+![履歴表示](docs/images/history-view.png)
+
+### 設定
+アプリをカスタマイズ：
+- プラン選択（Pro/Max5/Max20）
+- 自動更新間隔
+- 言語設定（英語/日本語）
+
+![設定タブ](docs/images/settings-tab.png)
 
 ## 🤝 コントリビューション
 
@@ -132,8 +162,8 @@ open ClaudeUsageMonitor.app
 
 ## 💬 サポート
 
-- **Issues**: [GitHub Issues](https://github.com/K9i-0/ClaudeUsageMonitor/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/K9i-0/ClaudeUsageMonitor/discussions)
+- **Issues**: [GitHub Issues](https://github.com/K9i-0/ClaudeCodeMonitor/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/K9i-0/ClaudeCodeMonitor/discussions)
 
 ## 🔗 関連リンク
 

--- a/README.md
+++ b/README.md
@@ -105,9 +105,39 @@ open ClaudeCodeMonitor.app
 
 ## 🖼️ Screenshots
 
-<p align="center">
-  <i>Screenshots coming soon</i>
-</p>
+### Menubar Icon
+Shows current session usage percentage directly in your menubar:
+- 🔵 Blue (0-50%): Safe usage zone
+- 🟠 Orange (50-75%): Moderate usage
+- 🔴 Red (75%+): High usage warning
+
+![Menubar Icon](docs/images/menubar-icon.png)
+
+### Current Session View
+Detailed view of your current 5-hour session:
+- Large, easy-to-read remaining tokens display
+- Visual progress bar with color coding
+- Burn rate calculation (tokens/minute)
+- Estimated time remaining
+
+![Current Session](docs/images/current-session.png)
+
+### History View
+Track your usage patterns over time:
+- Session-by-session breakdown
+- Daily usage summaries
+- Model-specific usage statistics
+- Cost tracking (reference values)
+
+![History View](docs/images/history-view.png)
+
+### Settings
+Customize the app to your needs:
+- Plan selection (Pro/Max5/Max20)
+- Auto-refresh interval
+- Language preferences (English/Japanese)
+
+![Settings Tab](docs/images/settings-tab.png)
 
 ## 🤝 Contributing
 

--- a/docs/images/placeholder.md
+++ b/docs/images/placeholder.md
@@ -1,0 +1,14 @@
+# Placeholder Images
+
+This directory will contain screenshots of the application.
+
+## Required Screenshots:
+1. `menubar-icon.png` - Menubar icon showing usage percentage
+2. `current-session.png` - Current session view with token display
+3. `history-view.png` - History tab showing past sessions
+4. `settings-tab.png` - Settings tab with plan selection
+
+## How to generate:
+1. Build and run the app using Xcode
+2. Take screenshots using ⌘ + Shift + 5
+3. Save them in this directory with the specified names

--- a/docs/screenshots-guide.md
+++ b/docs/screenshots-guide.md
@@ -1,0 +1,58 @@
+# スクリーンショット撮影ガイド
+
+## 準備
+
+1. **サーバーの起動**
+```bash
+cd server
+npm install  # 初回のみ
+npm start
+```
+
+2. **Xcodeでビルド**
+```bash
+open Package.swift
+```
+- Xcodeが開いたら、⌘B でビルド
+- ⌘R で実行
+
+## 撮影するスクリーンショット
+
+### 1. メニューバーアイコン
+- 通常状態（使用率表示）
+- クリック時のポップオーバー
+
+### 2. Current Session タブ
+- 残りトークン表示
+- プログレスバー
+- バーンレート
+- セッション情報
+
+### 3. History タブ
+- 過去のセッション一覧
+- 日別使用状況
+
+### 4. Settings タブ
+- プラン選択
+- 更新間隔設定
+
+### 5. 通知
+- 90%使用時の通知
+
+## 撮影方法
+
+1. ⌘ + Shift + 5 でスクリーンショットツールを起動
+2. 「選択部分を取り込む」を選択
+3. 必要な部分を選択して撮影
+
+## ファイル名規則
+
+- `menubar-icon.png` - メニューバーアイコン
+- `current-session.png` - Current Sessionタブ
+- `history-view.png` - Historyタブ
+- `settings-tab.png` - Settingsタブ
+- `notification.png` - 通知
+
+## 保存場所
+
+`docs/images/` ディレクトリに保存


### PR DESCRIPTION
## 概要
READMEにスクリーンショットの説明を追加し、将来的なスクリーンショット追加の準備を整えました。

## 変更内容
- README（英語/日本語）にスクリーンショットの詳細説明を追加
- 各機能の視覚的な説明を追加（メニューバー、セッション表示、履歴、設定）
- 日本語READMEのリポジトリURLを修正
- スクリーンショット撮影ガイドを作成

## 注意事項
- 実際のスクリーンショットは後日追加予定
- 現在はプレースホルダーとして説明文のみ

## 関連Issue
- Linear: K9I-36 (ドキュメント整備)