### PR TITLE
fix: remove non-existent icon reference in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,10 +98,9 @@ jobs:
         # Install create-dmg
         brew install create-dmg
         
-        # Create DMG with custom settings
+        # Create DMG with custom settings (without icon for now)
         create-dmg \
           --volname "Claude Code Monitor" \
-          --volicon "ClaudeCodeMonitor.app/Contents/Resources/AppIcon.icns" \
           --window-pos 200 120 \
           --window-size 600 400 \
           --icon-size 100 \


### PR DESCRIPTION
## 概要
リリースワークフローでDMG作成が失敗する問題を修正しました。

## 問題
- `AppIcon.icns`ファイルが存在しないため、DMG作成時にエラーが発生
- v0.1.0のテストリリースで発覚

## 修正内容
- `--volicon`オプションを削除
- アイコンは将来のリリースで追加予定

## テスト
- このPRマージ後、再度タグをプッシュしてワークフローの動作を確認

## 関連
- #11 (v1.0.0リリース準備)