### PR TITLE
fix: preserve resource bundle structure in app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
         mkdir -p ClaudeCodeMonitor.app/Contents/Resources
         cp ClaudeCodeMonitor ClaudeCodeMonitor.app/Contents/MacOS/
         cp Info.plist ClaudeCodeMonitor.app/Contents/
-        # Copy localization resources
-        cp -R .build/arm64-apple-macosx/release/ClaudeCodeMonitor_ClaudeCodeMonitor.bundle/* ClaudeCodeMonitor.app/Contents/Resources/ || true
+        # Copy resource bundle
+        cp -R .build/arm64-apple-macosx/release/ClaudeCodeMonitor_ClaudeCodeMonitor.bundle ClaudeCodeMonitor.app/Contents/Resources/ || true
         # Update version in Info.plist
         /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${{ steps.version.outputs.version }}" ClaudeCodeMonitor.app/Contents/Info.plist
         /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${{ steps.version.outputs.version }}" ClaudeCodeMonitor.app/Contents/Info.plist


### PR DESCRIPTION
## 概要
リソースバンドルの構造を保持して、実行時エラーを修正しました。

## 問題
- アプリ起動時に「could not load resource bundle」エラーが発生
- リソースバンドルの中身だけをコピーしていたため、バンドル構造が失われていた

## 修正内容
- `ClaudeCodeMonitor_ClaudeCodeMonitor.bundle`ディレクトリ全体をResourcesフォルダにコピー
- これによりアプリが正しくリソースバンドルを認識できるように

## テスト
- 手元でアプリバンドルを作成し、正常に起動することを確認
- ccusageの実行も成功（フォールバックモード）

## 関連
- #13 の修正では不完全だった問題を解決