### PR TITLE
feat: create Homebrew Cask formula with short name 'ccmonitor'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,24 @@ open Package.swift
 - Resource bundles in `Sources/ClaudeUsageMonitor/Resources/`
 - LanguageSettings.swift manages language preferences
 
+## Code Signing and Distribution
+
+### Current Status
+- Using ad-hoc signing (`--sign -`) for development releases
+- This causes Gatekeeper warnings on first launch
+- Users need to manually approve in System Settings
+
+### Future: Developer ID Signing
+When Apple Developer Program is available:
+1. Update `DEVELOPER_ID` in `scripts/build-release.sh`
+2. Add notarization step to release workflow
+3. Benefits: No Gatekeeper warnings, smoother user experience
+
+### Distribution Channels Priority
+1. **Homebrew Cask** - Primary distribution method
+2. **GitHub Releases** - Direct DMG downloads
+3. **App Store** - Not recommended due to Sandbox limitations
+
 ## Technical Decisions
 
 ### ccusage Execution Strategy

--- a/README.ja.md
+++ b/README.ja.md
@@ -41,9 +41,16 @@ macOSのメニューバーに常駐し、Claude Codeの使用状況をリアル�
 
 ## 🚀 インストール
 
-### 今後の予定
-- **Homebrew Cask**: `brew install --cask ccmonitor` (準備中)
-- **App Store**: Mac App Storeから直接インストール (準備中)
+### Homebrew Cask（準備中）
+```bash
+brew install --cask ccmonitor
+```
+
+**注意**: 初回起動時に「開発元を検証できません」と表示される場合：
+1. 警告ダイアログで「キャンセル」をクリック
+2. システム設定 → プライバシーとセキュリティを開く
+3. Claude Code Monitorの「このまま開く」をクリック
+4. またはアプリを右クリックして「開く」を選択
 
 ### 現在の方法（ソースからビルド）
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -42,7 +42,7 @@ macOSのメニューバーに常駐し、Claude Codeの使用状況をリアル�
 ## 🚀 インストール
 
 ### 今後の予定
-- **Homebrew Cask**: `brew install --cask claude-usage-monitor` (準備中)
+- **Homebrew Cask**: `brew install --cask ccmonitor` (準備中)
 - **App Store**: Mac App Storeから直接インストール (準備中)
 
 ### 現在の方法（ソースからビルド）

--- a/README.md
+++ b/README.md
@@ -41,9 +41,16 @@ This app wraps the [ccusage](https://github.com/ryoppippi/ccusage) CLI tool to p
 
 ## 🚀 Installation
 
-### Coming Soon
-- **Homebrew Cask**: `brew install --cask ccmonitor` (in preparation)
-- **App Store**: Direct installation from Mac App Store (in preparation)
+### Homebrew Cask (Coming Soon)
+```bash
+brew install --cask ccmonitor
+```
+
+**Note**: On first launch, you may see "Cannot be opened because the developer cannot be verified":
+1. Click "Cancel" on the warning dialog
+2. Open System Settings → Privacy & Security
+3. Click "Open Anyway" for Claude Code Monitor
+4. Or simply right-click the app and select "Open"
 
 ### Current Method (Build from Source)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This app wraps the [ccusage](https://github.com/ryoppippi/ccusage) CLI tool to p
 ## 🚀 Installation
 
 ### Coming Soon
-- **Homebrew Cask**: `brew install --cask claude-usage-monitor` (in preparation)
+- **Homebrew Cask**: `brew install --cask ccmonitor` (in preparation)
 - **App Store**: Direct installation from Mac App Store (in preparation)
 
 ### Current Method (Build from Source)

--- a/create-csr.sh
+++ b/create-csr.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# CSR作成スクリプト
+# キーチェーンアクセスを使わずにコマンドラインでCSRを作成
+
+echo "Creating Certificate Signing Request (CSR)..."
+
+# CSRのための設定ファイルを作成
+cat > csr.conf <<EOF
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+
+[ dn ]
+CN = Claude Code Monitor Developer ID
+emailAddress = your-email@example.com
+C = JP
+ST = Tokyo
+L = Tokyo
+O = Your Organization Name
+OU = Development
+EOF
+
+# 秘密鍵とCSRを生成
+openssl req -new -newkey rsa:2048 -nodes \
+    -keyout developerID.key \
+    -out developerID.csr \
+    -config csr.conf
+
+echo "CSR created: developerID.csr"
+echo "Upload this CSR file to Apple Developer portal"
+
+# 一時ファイルを削除
+rm csr.conf

--- a/homebrew/ccmonitor.rb
+++ b/homebrew/ccmonitor.rb
@@ -1,0 +1,26 @@
+cask "ccmonitor" do
+  version "1.0.0"
+  sha256 "PLACEHOLDER_SHA256"  # This will be updated after release
+
+  url "https://github.com/K9i-0/ClaudeCodeMonitor/releases/download/v#{version}/ClaudeCodeMonitor-#{version}.dmg"
+  name "Claude Code Monitor"
+  desc "Real-time monitoring for Claude Code API usage"
+  homepage "https://github.com/K9i-0/ClaudeCodeMonitor"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates false
+  depends_on macos: ">= :ventura"
+
+  app "Claude Code Monitor.app"
+
+  uninstall quit: "com.k9i.claude-code-monitor"
+
+  zap trash: [
+    "~/Library/Preferences/com.k9i.claude-code-monitor.plist",
+    "~/Library/Application Support/Claude Code Monitor",
+  ]
+end

--- a/homebrew/ccmonitor.rb
+++ b/homebrew/ccmonitor.rb
@@ -1,6 +1,6 @@
 cask "ccmonitor" do
-  version "1.0.0"
-  sha256 "PLACEHOLDER_SHA256"  # This will be updated after release
+  version "0.1.5"
+  sha256 "f6004ac4931a90506c032e25afbd75ee43334fcf82add57cd429f7ca4d3b6e72"
 
   url "https://github.com/K9i-0/ClaudeCodeMonitor/releases/download/v#{version}/ClaudeCodeMonitor-#{version}.dmg"
   name "Claude Code Monitor"
@@ -15,7 +15,7 @@ cask "ccmonitor" do
   auto_updates false
   depends_on macos: ">= :ventura"
 
-  app "Claude Code Monitor.app"
+  app "ClaudeCodeMonitor.app"
 
   uninstall quit: "com.k9i.claude-code-monitor"
 

--- a/setup-signing.md
+++ b/setup-signing.md
@@ -1,0 +1,62 @@
+# Developer ID 署名セットアップガイド
+
+## 1. 証明書の確認
+
+```bash
+# インストール済みの証明書を確認
+security find-identity -v -p codesigning
+
+# Developer ID Application証明書を探す
+security find-identity -v -p codesigning | grep "Developer ID Application"
+```
+
+## 2. build-release.sh の更新
+
+証明書が見つかったら、スクリプトの以下の部分を更新：
+
+```bash
+# 現在の設定（13行目）
+DEVELOPER_ID="Developer ID Application: Your Name (XXXXXXXXXX)"
+
+# あなたの証明書情報に置き換える
+# 例: DEVELOPER_ID="Developer ID Application: Kotaro Hayashi (ABC123DEF4)"
+```
+
+## 3. 署名付きビルドの実行
+
+```bash
+# 署名付きでビルド
+./scripts/build-release.sh
+
+# 署名を確認
+codesign -dv --verbose=4 "Claude Code Monitor.app"
+spctl -a -vvv -t install "Claude Code Monitor.app"
+```
+
+## 4. 公証（Notarization）- オプション
+
+macOS 10.15以降では公証も推奨：
+
+```bash
+# App Store Connect API キーが必要
+xcrun notarytool submit ClaudeCodeMonitor-1.0.0.dmg \
+    --key-id YOUR_KEY_ID \
+    --key YOUR_API_KEY_FILE \
+    --issuer YOUR_ISSUER_ID \
+    --wait
+
+# 公証後、DMGにステープル
+xcrun stapler staple ClaudeCodeMonitor-1.0.0.dmg
+```
+
+## トラブルシューティング
+
+### 証明書が見つからない場合
+1. Xcodeで再度ダウンロード
+2. ダウンロードした.cerファイルをダブルクリックしてキーチェーンに追加
+
+### 署名エラーが出る場合
+```bash
+# キーチェーンのロックを解除
+security unlock-keychain -p "パスワード" ~/Library/Keychains/login.keychain-db
+```


### PR DESCRIPTION
## 概要
Homebrew Caskで簡単にインストールできるようにFormulaを作成しました。

## 変更内容
- 短縮名`ccmonitor`でのCask formula作成
- READMEのインストールコマンドを更新

## インストール方法（PR承認後）
```bash
brew install --cask ccmonitor
```

## 注意事項
- 正式なHomebrew Caskリポジトリへの提出はv1.0.0リリース後に行う予定
- 現在はドラフトとして準備のみ

## 関連Issue
- Linear: K9I-34 (Homebrew Cask対応)