### PR TITLE
fix: improve history display and disable notifications

### DIFF
--- a/Sources/ClaudeUsageMonitor/AppDelegate.swift
+++ b/Sources/ClaudeUsageMonitor/AppDelegate.swift
@@ -12,10 +12,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         usageMonitor = UsageMonitor()
         
+        // 通知機能は初回リリースでは無効化
+        /*
         // Setup notification center delegate
         if Bundle.main.bundleIdentifier != nil {
             UNUserNotificationCenter.current().delegate = NotificationManager.shared
         }
+        */
         
         // Hide all windows for menubar-only app
         NSApp.windows.forEach { window in

--- a/Sources/ClaudeUsageMonitor/HistoryView.swift
+++ b/Sources/ClaudeUsageMonitor/HistoryView.swift
@@ -69,29 +69,25 @@ struct HistoryView: View {
                 )
             }
             
-            // 今日と今月の統計（横並び）
+            // 今日と今月の統計（横並び）- アクティブセッションに関係なく表示
             HStack(spacing: 12) {
                 // 今日の使用量
-                if let daily = monitor.usageData.todayUsage {
-                    StatCard(
-                        icon: "calendar",
-                        title: L10n.Usage.today,
-                        cost: monitor.formatCost(daily.totalCost),
-                        tokens: monitor.formatTokens(daily.inputTokens + daily.outputTokens),
-                        accentColor: .green
-                    )
-                }
+                StatCard(
+                    icon: "calendar",
+                    title: L10n.Usage.today,
+                    cost: monitor.formatCost(monitor.usageData.todayUsage?.totalCost ?? 0),
+                    tokens: monitor.formatTokens((monitor.usageData.todayUsage?.inputTokens ?? 0) + (monitor.usageData.todayUsage?.outputTokens ?? 0)),
+                    accentColor: .green
+                )
                 
                 // 今月の使用量
-                if let monthly = monitor.usageData.monthlyTotal {
-                    StatCard(
-                        icon: "calendar.badge.clock",
-                        title: L10n.Usage.thisMonth,
-                        cost: monitor.formatCost(monthly.totalCost),
-                        tokens: monitor.formatTokens(monthly.inputTokens + monthly.outputTokens),
-                        accentColor: .purple
-                    )
-                }
+                StatCard(
+                    icon: "calendar.badge.clock",
+                    title: L10n.Usage.thisMonth,
+                    cost: monitor.formatCost(monitor.usageData.monthlyTotal?.totalCost ?? 0),
+                    tokens: monitor.formatTokens((monitor.usageData.monthlyTotal?.inputTokens ?? 0) + (monitor.usageData.monthlyTotal?.outputTokens ?? 0)),
+                    accentColor: .purple
+                )
             }
             
             Text(L10n.History.referenceNote)

--- a/Sources/ClaudeUsageMonitor/SettingsTabView.swift
+++ b/Sources/ClaudeUsageMonitor/SettingsTabView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SettingsTabView: View {
     @EnvironmentObject var monitor: UsageMonitor
     @StateObject private var languageSettings = LanguageSettings.shared
-    @State private var notificationEnabled = Bundle.main.bundleIdentifier != nil ? NotificationManager.shared.isNotificationEnabled : false
+    // @State private var notificationEnabled = Bundle.main.bundleIdentifier != nil ? NotificationManager.shared.isNotificationEnabled : false
     
     let plans = [
         ("Pro", "7,000 tokens/session", L10n.Plan.pro),
@@ -80,6 +80,8 @@ struct SettingsTabView: View {
                 }
             }
             
+            // 通知機能は初回リリースでは無効化
+            /*
             Divider()
             
             // Notification settings section
@@ -113,6 +115,7 @@ struct SettingsTabView: View {
                         .padding(.leading, 26)
                 }
             }
+            */
             
             Spacer()
         }

--- a/Sources/ClaudeUsageMonitor/UsageMonitor.swift
+++ b/Sources/ClaudeUsageMonitor/UsageMonitor.swift
@@ -71,7 +71,11 @@ class UsageMonitor: ObservableObject, UsageMonitoring {
         do {
             // Try local server first
             if let url = URL(string: "http://127.0.0.1:3456/usage") {
-                let (data, response) = try await URLSession.shared.data(from: url)
+                var request = URLRequest(url: url)
+                request.timeoutInterval = 5.0 // 5 second timeout
+                
+                print("Attempting to fetch from server: \(url)")
+                let (data, response) = try await URLSession.shared.data(for: request)
                 
                 if let httpResponse = response as? HTTPURLResponse {
                     guard httpResponse.statusCode == 200 else {
@@ -85,23 +89,34 @@ class UsageMonitor: ObservableObject, UsageMonitoring {
                     if let first = ccusageResponse.daily.first {
                         print("First daily entry: date=\(first.date), cost=$\(first.totalCost)")
                     }
+                    if let last = ccusageResponse.daily.last {
+                        print("Last daily entry: date=\(last.date), cost=$\(last.totalCost)")
+                    }
                     print("Monthly total: $\(ccusageResponse.totals.totalCost)")
                     
                     // Get today's date in YYYY-MM-DD format
                     let formatter = DateFormatter()
                     formatter.dateFormat = "yyyy-MM-dd"
                     let today = formatter.string(from: Date())
+                    print("Looking for today's date: \(today)")
                     
                     // Find today's usage from the array
                     if let todayData = ccusageResponse.daily.first(where: { $0.date == today }) {
+                        print("Found today's data: cost=$\(todayData.totalCost)")
                         usageData.todayUsage = todayData
                     } else {
+                        print("No data found for today")
                         usageData.todayUsage = nil
                     }
                     
                     // Store monthly total
                     usageData.monthlyTotal = ccusageResponse.totals
                     usageData.lastUpdated = Date()
+                    
+                    // Debug final state
+                    print("Final state - Today's cost: $\(usageData.todayUsage?.totalCost ?? 0)")
+                    print("Final state - Monthly cost: $\(usageData.monthlyTotal?.totalCost ?? 0)")
+                    
                     isLoading = false
                     return
                 }
@@ -112,7 +127,10 @@ class UsageMonitor: ObservableObject, UsageMonitoring {
         } catch {
             // Server not running or request failed
             print("Local server not available: \(error.localizedDescription)")
+            print("Error type: \(type(of: error))")
+            print("Full error: \(error)")
             self.error = ClaudeMonitorError.networkError(L10n.Error.serverNotRunning)
+            isLoading = false
             return
         }
         
@@ -412,7 +430,9 @@ class UsageMonitor: ObservableObject, UsageMonitoring {
     }
     
     func formatCost(_ cost: Double) -> String {
-        return NumberFormatters.formatCost(cost)
+        let formatted = NumberFormatters.formatCost(cost)
+        print("formatCost input: \(cost), output: \(formatted)")
+        return formatted
     }
     
     private func updateDetectedPlan(_ plan: String) {

--- a/Sources/ClaudeUsageMonitor/UsageMonitor.swift
+++ b/Sources/ClaudeUsageMonitor/UsageMonitor.swift
@@ -430,9 +430,7 @@ class UsageMonitor: ObservableObject, UsageMonitoring {
     }
     
     func formatCost(_ cost: Double) -> String {
-        let formatted = NumberFormatters.formatCost(cost)
-        print("formatCost input: \(cost), output: \(formatted)")
-        return formatted
+        return NumberFormatters.formatCost(cost)
     }
     
     private func updateDetectedPlan(_ plan: String) {

--- a/Sources/ClaudeUsageMonitor/ViewModels/SessionViewModel.swift
+++ b/Sources/ClaudeUsageMonitor/ViewModels/SessionViewModel.swift
@@ -34,6 +34,8 @@ class SessionViewModel: ObservableObject {
         planDescription = monitor.usageData.planDescription
         resetTime = Date.formatTime(from: data.endTime)
         
+        // 通知機能は初回リリースでは無効化
+        /*
         // 通知チェック（テスト環境では無効）
         if Bundle.main.bundleIdentifier != nil && !ProcessInfo.processInfo.environment.keys.contains("XCTestConfigurationFilePath") {
             NotificationManager.shared.checkAndSendNotification(
@@ -43,6 +45,7 @@ class SessionViewModel: ObservableObject {
                 sessionId: data.id
             )
         }
+        */
     }
     
     var formattedRemainingTokens: String {

--- a/docs/HOMEBREW_SUBMISSION_GUIDE.md
+++ b/docs/HOMEBREW_SUBMISSION_GUIDE.md
@@ -1,0 +1,228 @@
+# Homebrew Cask Submission Guide for Claude Code Monitor
+
+This guide provides step-by-step instructions for submitting Claude Code Monitor (ccmonitor) to Homebrew Cask.
+
+## Pre-submission Checklist
+
+Before starting the submission process, ensure you have:
+
+- [ ] A stable release with a versioned DMG file
+- [ ] The DMG is hosted on a reliable, permanent URL (GitHub Releases recommended)
+- [ ] SHA256 checksum of the DMG file
+- [ ] The app is properly code-signed (ad-hoc signing is acceptable)
+- [ ] The app has been tested on a clean macOS installation
+- [ ] Homebrew is installed and up to date: `brew update`
+- [ ] You have a GitHub account
+- [ ] The app follows macOS naming conventions (e.g., `ClaudeCodeMonitor.app`)
+
+## Step 1: Calculate SHA256 Checksum
+
+```bash
+# Calculate the SHA256 of your DMG file
+shasum -a 256 ClaudeCodeMonitor-v1.0.0.dmg
+# Example output: abc123def456... ClaudeCodeMonitor-v1.0.0.dmg
+```
+
+## Step 2: Fork and Clone Homebrew Cask
+
+```bash
+# Fork the homebrew-cask repository on GitHub (via web interface)
+# Then clone your fork
+git clone https://github.com/YOUR_USERNAME/homebrew-cask.git
+cd homebrew-cask
+
+# Add the upstream remote
+git remote add upstream https://github.com/Homebrew/homebrew-cask.git
+
+# Create a new branch for your cask
+git checkout -b claude-code-monitor
+```
+
+## Step 3: Create the Cask File
+
+Create a new file at `Casks/c/claude-code-monitor.rb`:
+
+```ruby
+cask "claude-code-monitor" do
+  version "1.0.0"
+  sha256 "YOUR_SHA256_CHECKSUM_HERE"
+
+  url "https://github.com/K9i-0/claude-code-monitor/releases/download/v#{version}/ClaudeCodeMonitor-v#{version}.dmg"
+  name "Claude Code Monitor"
+  desc "Monitor Claude Code API usage and costs from your menubar"
+  homepage "https://github.com/K9i-0/claude-code-monitor"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "ClaudeCodeMonitor.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.k9i.ClaudeCodeMonitor.plist",
+    "~/Library/Application Support/ClaudeCodeMonitor",
+  ]
+end
+```
+
+## Step 4: Validate Your Cask
+
+```bash
+# Install your cask locally to test it
+brew install --cask ./Casks/c/claude-code-monitor.rb
+
+# Run audit to check for common issues
+brew audit --new-cask claude-code-monitor
+
+# Run style checks
+brew style --fix Casks/c/claude-code-monitor.rb
+
+# Test the installation
+brew reinstall --cask claude-code-monitor
+
+# Test uninstallation
+brew uninstall --cask claude-code-monitor
+
+# Test zap (complete removal including preferences)
+brew uninstall --zap --cask claude-code-monitor
+```
+
+## Step 5: Common Issues and Fixes
+
+### Issue: Audit fails with "url unversioned"
+**Fix:** Ensure your URL contains the `#{version}` interpolation
+
+### Issue: "No checksum defined"
+**Fix:** Add the `sha256` line with the correct checksum
+
+### Issue: "Cask name doesn't match file name"
+**Fix:** Ensure the cask name in the file matches the filename (without .rb)
+
+### Issue: "Homepage SSL verification failed"
+**Fix:** Ensure your homepage uses HTTPS with a valid certificate
+
+### Issue: "App sandbox validation failed"
+**Fix:** This is just a warning for sandboxed apps - it's acceptable
+
+### Issue: "Code signing verification failed"
+**Fix:** Ad-hoc signing is acceptable, but ensure the app is signed:
+```bash
+codesign -dv --verbose=4 /Applications/ClaudeCodeMonitor.app
+```
+
+## Step 6: Commit Your Changes
+
+```bash
+# Add your cask file
+git add Casks/c/claude-code-monitor.rb
+
+# Commit with a descriptive message
+git commit -m "Add Claude Code Monitor 1.0.0"
+
+# Push to your fork
+git push origin claude-code-monitor
+```
+
+## Step 7: Create Pull Request
+
+### PR Title
+```
+Add Claude Code Monitor 1.0.0
+```
+
+### PR Template
+```markdown
+### Pre-submission checklist
+- [x] The cask was submitted via a pull request to the correct repo (homebrew-cask)
+- [x] I've checked the cask doesn't already exist with `brew search claude-code-monitor`
+- [x] I've run `brew audit --new-cask claude-code-monitor` and addressed any issues
+- [x] I've run `brew style --fix Casks/c/claude-code-monitor.rb` and fixed any style issues
+- [x] I've checked the cask installs and uninstalls successfully
+- [x] The app is stable and reproducible (not a beta or nightly build)
+
+### Description
+Claude Code Monitor is a macOS menubar application that monitors Claude Code API usage and costs in real-time.
+
+### Additional Information
+- The app uses ad-hoc code signing, which is acceptable for Homebrew Cask
+- Requires Node.js runtime for the ccusage CLI tool integration
+- App runs as menubar-only (LSUIElement)
+- Supports macOS 13.0 (Ventura) and later
+
+### Release URL
+https://github.com/K9i-0/claude-code-monitor/releases/tag/v1.0.0
+```
+
+## Step 8: Respond to Feedback
+
+After submitting the PR:
+
+1. **Monitor CI checks** - Fix any failing tests
+2. **Respond to reviewer comments** - Usually within 24-48 hours
+3. **Make requested changes** - Push additional commits to your branch
+4. **Be patient** - Review process can take a few days to a week
+
+## Post-Submission Maintenance
+
+Once accepted:
+
+### Updating the Cask for New Releases
+
+```bash
+# Update your fork
+git checkout master
+git pull upstream master
+git push origin master
+
+# Create a new branch
+git checkout -b update-claude-code-monitor-1.1.0
+
+# Edit the cask file with new version and SHA256
+# Then commit and create a new PR
+```
+
+### Testing Updates
+```bash
+# Test version updates work correctly
+brew livecheck claude-code-monitor
+```
+
+## Troubleshooting Tips
+
+1. **Always test on a clean macOS VM if possible**
+2. **Check existing casks for similar apps as examples**
+3. **Join Homebrew's Discourse forum for help**
+4. **Review recent merged PRs for current best practices**
+
+## Useful Commands Reference
+
+```bash
+# Check if cask already exists
+brew search claude-code-monitor
+
+# View cask info
+brew info --cask claude-code-monitor
+
+# Check for updates
+brew livecheck claude-code-monitor
+
+# View installed casks
+brew list --cask
+
+# Check cask dependencies
+brew deps claude-code-monitor
+```
+
+## Resources
+
+- [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook)
+- [Acceptable Casks](https://docs.brew.sh/Acceptable-Casks)
+- [Homebrew Discourse](https://discourse.brew.sh/)
+- [Example PR for menubar app](https://github.com/Homebrew/homebrew-cask/pull/140000)
+
+---
+
+Remember: The Homebrew maintainers are volunteers. Be respectful, patient, and appreciative of their time and effort in reviewing your submission.

--- a/homebrew-cask-pr-checklist.md
+++ b/homebrew-cask-pr-checklist.md
@@ -1,0 +1,126 @@
+# Homebrew Cask PR提出チェックリスト
+
+## ✅ 事前確認
+
+- [x] **安定版リリース**: v0.1.5がGitHub Releasesで公開済み
+- [x] **DMGファイル**: ClaudeCodeMonitor-0.1.5.dmg
+- [x] **SHA256**: f6004ac4931a90506c032e25afbd75ee43334fcf82add57cd429f7ca4d3b6e72
+- [x] **署名**: ad-hoc署名（Homebrew Caskで許容）
+- [x] **README**: 初回起動時の手順を記載済み
+
+## 📝 すぐに実行する手順
+
+### 1. Homebrew-caskをフォーク
+https://github.com/Homebrew/homebrew-cask → "Fork"ボタン
+
+### 2. ローカルにクローン
+```bash
+# あなたのGitHubユーザー名に置き換え
+git clone https://github.com/YOUR_USERNAME/homebrew-cask.git
+cd homebrew-cask
+git remote add upstream https://github.com/Homebrew/homebrew-cask.git
+```
+
+### 3. 最新の状態に更新
+```bash
+git fetch upstream
+git checkout master
+git merge upstream/master
+git checkout -b add-claude-code-monitor
+```
+
+### 4. Caskファイルをコピー
+```bash
+cp /Users/kotahayashi/Workspace/ClaudeCodeMonitor/homebrew/ccmonitor.rb Casks/c/ccmonitor.rb
+```
+
+### 5. 検証（重要！）
+```bash
+# 新規Caskの監査
+brew audit --new-cask ccmonitor
+
+# スタイルチェック
+brew style --fix ccmonitor
+
+# インストールテスト
+brew install --cask --verbose ./Casks/c/ccmonitor.rb
+brew uninstall --cask ccmonitor
+```
+
+### 6. コミット
+```bash
+git add Casks/c/ccmonitor.rb
+git commit -m "Add ccmonitor 0.1.5"
+```
+
+### 7. プッシュ
+```bash
+git push origin add-claude-code-monitor
+```
+
+### 8. PR作成
+GitHubで自動表示される"Compare & pull request"ボタンをクリック
+
+## 📋 PR本文テンプレート
+
+```markdown
+#### Pre-merge checklist
+- [x] The cask is named [`ccmonitor`](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/c/ccmonitor.rb).
+- [x] The cask has been audited with `brew audit --new-cask ccmonitor`.
+- [x] The cask has been styled with `brew style --fix ccmonitor`.
+- [x] The cask has been tested with `brew install --cask ccmonitor`.
+- [x] The submission is for [a stable version](https://github.com/K9i-0/ClaudeCodeMonitor/releases/tag/v0.1.5) of the software.
+- [x] I have read the [Acceptable Casks document](https://docs.brew.sh/Acceptable-Casks).
+
+#### App details
+- **Name**: Claude Code Monitor
+- **Homepage**: https://github.com/K9i-0/ClaudeCodeMonitor
+- **Description**: Monitor Claude Code API usage and costs in your menubar
+- **Version**: 0.1.5
+- **macOS requirement**: 13.0+ (Ventura)
+
+#### Notes
+- The app uses ad-hoc signing. First-time users need to allow it in System Settings → Privacy & Security.
+- Instructions for this are documented in the [README](https://github.com/K9i-0/ClaudeCodeMonitor#homebrew-cask-coming-soon).
+```
+
+## ⚠️ よくある指摘と対応
+
+1. **"Description is too generic"**
+   → 現在の説明は具体的なので問題なし
+
+2. **"Please squash commits"**
+   ```bash
+   git rebase -i upstream/master
+   # すべてのコミットを1つにまとめる
+   ```
+
+3. **"CI is failing"**
+   → ログを確認して修正
+
+4. **"App is not signed"**
+   → ad-hoc署名は許容される。READMEに手順記載済みと説明
+
+## 🔍 署名の確認方法
+
+メンテナーから署名について聞かれた場合：
+```bash
+codesign -dv --verbose=4 /Applications/ClaudeCodeMonitor.app 2>&1 | grep Signature
+# 出力: Signature=adhoc
+```
+
+これはHomebrew Caskで許容される署名タイプです。
+
+## 📅 タイムライン
+
+1. **今すぐ**: PR提出（5-10分）
+2. **1-3日**: 初回レビュー
+3. **3-7日**: フィードバック対応
+4. **1-2週間**: マージ
+
+## 🚀 次のステップ
+
+PR提出後：
+1. CI結果を確認
+2. メンテナーのフィードバックに迅速に対応
+3. マージされたら、READMEを更新して"Coming Soon"を削除

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server-fixed.js"
   },
   "dependencies": {
     "ccusage": "^0.8.0",

--- a/server/server-fixed.js
+++ b/server/server-fixed.js
@@ -1,0 +1,73 @@
+import express from 'express';
+import { spawn } from 'child_process';
+
+const app = express();
+const PORT = 3456;
+
+// Helper function to run npx ccusage command
+function runCcusage(args) {
+  return new Promise((resolve, reject) => {
+    const npx = spawn('npx', ['ccusage@latest', ...args]);
+    let output = '';
+    let error = '';
+
+    npx.stdout.on('data', (data) => {
+      output += data.toString();
+    });
+
+    npx.stderr.on('data', (data) => {
+      error += data.toString();
+    });
+
+    npx.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(error || 'Command failed'));
+      } else {
+        try {
+          const data = JSON.parse(output);
+          resolve(data);
+        } catch (e) {
+          reject(new Error('Failed to parse output'));
+        }
+      }
+    });
+  });
+}
+
+app.get('/usage', async (req, res) => {
+  try {
+    // Run npx ccusage@latest --json to get the full data
+    const data = await runCcusage(['--json']);
+    
+    console.log('Daily count:', data.daily.length);
+    if (data.daily.length > 0) {
+      console.log('First daily entry:', data.daily[0]);
+    }
+    console.log('Monthly total cost:', data.totals.totalCost);
+    
+    res.json(data);
+  } catch (error) {
+    console.error('Error fetching usage data:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Get active session block data
+app.get('/blocks/active', async (req, res) => {
+  try {
+    const data = await runCcusage(['blocks', '--active', '--json']);
+    res.json(data);
+  } catch (error) {
+    console.error('Error fetching blocks data:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Health check endpoint
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, '127.0.0.1', () => {
+  console.log(`Claude usage server (fixed) running on http://127.0.0.1:${PORT}`);
+});


### PR DESCRIPTION
## 概要
アクティブセッションがない時でも履歴データを表示できるように修正し、初回リリースでは通知機能を無効化しました。

## 変更内容

### 1. 履歴表示の修正
- アクティブセッションがない場合でも、日次・月次の統計を表示
- データがない場合は `/bin/zsh.00` と `0 tokens` を表示

### 2. 通知機能の一時無効化
- 初回リリースをシンプルにするため通知機能をコメントアウト
- コードは保持されているため、将来的に簡単に有効化可能
- 影響箇所：
  - SettingsTabView（通知設定UI）
  - SessionViewModel（通知チェック）
  - AppDelegate（通知デリゲート）

## スクリーンショット
アクティブセッションがない時でも、日次・月次データが表示されます。

## テスト
- [x] アクティブセッションありで正常動作
- [x] アクティブセッションなしでも統計表示
- [x] 通知設定が表示されないこと確認