### PR TITLE
feat: introduce semantic versioning with PR labels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - main
 
@@ -12,6 +13,7 @@ jobs:
   build:
     name: Build and Release
     runs-on: macos-latest
+    if: github.event.pull_request.merged == true
     
     steps:
     - uses: actions/checkout@v4
@@ -21,13 +23,34 @@ jobs:
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_15.2.app
     
-    - name: Generate version tag
+    - name: Determine version bump type
+      id: version_type
+      run: |
+        # Check PR labels for version type
+        LABELS="${{ join(github.event.pull_request.labels.*.name, ',') }}"
+        echo "PR Labels: $LABELS"
+        
+        if [[ "$LABELS" == *"version:major"* ]]; then
+          echo "type=major" >> $GITHUB_OUTPUT
+        elif [[ "$LABELS" == *"version:minor"* ]]; then
+          echo "type=minor" >> $GITHUB_OUTPUT
+        else
+          echo "type=patch" >> $GITHUB_OUTPUT
+        fi
+    
+    - name: Bump version
       id: version
       run: |
-        # Generate timestamp-based tag
-        TAG="v$(date +%Y%m%d-%H%M%S)"
-        echo "tag=$TAG" >> $GITHUB_OUTPUT
-        echo "version=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_OUTPUT
+        VERSION_TYPE="${{ steps.version_type.outputs.type }}"
+        echo "Bumping version: $VERSION_TYPE"
+        
+        # Run bump script and capture output
+        ./scripts/bump-version.sh "$VERSION_TYPE"
+        
+        # Read the new version
+        NEW_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" Info.plist)
+        echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+        echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
     
     # Check if we have signing certificates
     - name: Check signing prerequisites
@@ -157,10 +180,8 @@ jobs:
         # Copy executable
         cp "$EXECUTABLE_PATH" "ClaudeCodeMonitor.app/Contents/MacOS/"
         
-        # Copy Info.plist and update version
+        # Copy Info.plist (version already updated by bump script)
         cp Info.plist "ClaudeCodeMonitor.app/Contents/"
-        /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${{ steps.version.outputs.version }}" "ClaudeCodeMonitor.app/Contents/Info.plist"
-        /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${{ steps.version.outputs.version }}" "ClaudeCodeMonitor.app/Contents/Info.plist"
         
         # Copy resource bundles if they exist (ONLY to Resources directory)
         echo "Looking for resource bundles..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,41 +1,9 @@
 # Changelog
 
-All notable changes to Claude Code Monitor will be documented in this file.
+All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
 
-## [1.0.0] - 2025-06-24
-
+## [1.0.0] - TBD
 ### Added
 - Initial release of Claude Code Monitor
-- Real-time session monitoring in macOS menubar
-- Support for Claude Code Pro/Max5/Max20 plans
-- Session-based usage tracking (5-hour sessions)
-- Visual progress indicators with color coding
-- Burn rate calculation (tokens/minute)
-- Time remaining predictions
-- Historical usage data viewing
-- Daily usage summaries
-- Model-specific usage breakdown
-- Cost tracking (reference values)
-- 90% usage threshold notifications
-- Multi-language support (English/Japanese)
-- Auto-refresh every 5 minutes
-- Manual refresh option
-- Local server mode for stable operation
-- App Sandbox enabled for security
-
-### Technical Details
-- Built with Swift 5.9 and SwiftUI
-- Requires macOS 13.0 or later
-- Uses ccusage CLI tool for data fetching
-- Implements MVVM architecture
-- Protocol-oriented design for testability
-
-### Known Issues
-- Requires Node.js 18+ for ccusage CLI
-- Initial release is not code-signed with Developer ID
-- Users may need to allow the app in Security & Privacy settings
-
-[1.0.0]: https://github.com/K9i-0/ClaudeCodeMonitor/releases/tag/v1.0.0

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
     <key>CFBundleExecutable</key>
     <string>ClaudeCodeMonitor</string>
     <key>CFBundleVersion</key>
-    <string>1.0.0</string>
+    <string>0.1.7</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.0</string>
+    <string>0.1.7</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>CFBundlePackageType</key>

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Bump version script for Claude Code Monitor
+# Usage: ./bump-version.sh [patch|minor|major]
+
+VERSION_TYPE=${1:-patch}
+
+# Get current version from Info.plist
+CURRENT_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" Info.plist)
+
+if [ -z "$CURRENT_VERSION" ]; then
+  echo "Error: Could not read current version from Info.plist"
+  exit 1
+fi
+
+echo "Current version: $CURRENT_VERSION"
+
+# Parse version components
+IFS='.' read -r -a VERSION_PARTS <<< "$CURRENT_VERSION"
+MAJOR="${VERSION_PARTS[0]}"
+MINOR="${VERSION_PARTS[1]}"
+PATCH="${VERSION_PARTS[2]}"
+
+# Increment version based on type
+case "$VERSION_TYPE" in
+  major)
+    MAJOR=$((MAJOR + 1))
+    MINOR=0
+    PATCH=0
+    ;;
+  minor)
+    MINOR=$((MINOR + 1))
+    PATCH=0
+    ;;
+  patch)
+    PATCH=$((PATCH + 1))
+    ;;
+  *)
+    echo "Error: Invalid version type. Use 'patch', 'minor', or 'major'"
+    exit 1
+    ;;
+esac
+
+NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+echo "New version: $NEW_VERSION"
+
+# Update Info.plist
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $NEW_VERSION" Info.plist
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $NEW_VERSION" Info.plist
+
+# Update Package.swift version comment (optional)
+if [ -f "Package.swift" ]; then
+  # Add or update version comment at the top of the file
+  if grep -q "// Version:" Package.swift; then
+    sed -i '' "s|// Version:.*|// Version: $NEW_VERSION|" Package.swift
+  else
+    sed -i '' "1i\\
+// Version: $NEW_VERSION\\
+" Package.swift
+  fi
+fi
+
+echo "✅ Version updated to $NEW_VERSION"
+echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Replace timestamp-based versioning with semantic versioning
- Use PR labels to control version bumps
- Simplify release workflow

## Changes
- **New versioning system**: Use standard semantic versioning (MAJOR.MINOR.PATCH)
- **PR label-based control**:
  - `version:major` → Major version bump (breaking changes)
  - `version:minor` → Minor version bump (new features)
  - No label → Patch version bump (bug fixes)
- **Workflow trigger change**: Now triggers on PR merge instead of direct push
- **Simplified CHANGELOG**: Pre-1.0 releases now have minimal changelog

## Test Plan
1. Merge this PR without any version label → Should bump to 0.1.8
2. Future PRs can use `version:minor` or `version:major` labels as needed

## Breaking Changes
- Release workflow now requires PRs (no direct push to main)
- Version format changed from timestamps to semantic versions