### PR TITLE
fix(release): アプリ起動失敗の問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,9 +198,9 @@ jobs:
         # Copy Info.plist (version already updated by bump script)
         cp Info.plist "ClaudeCodeMonitor.app/Contents/"
         
-        # Copy resource bundles if they exist (ONLY to Resources directory)
+        # Copy resource bundles from arm64 build (they are identical across architectures)
         echo "Looking for resource bundles..."
-        find .build -name "*.bundle" -type d | while read bundle; do
+        find .build -path "*arm64*/release/*.bundle" -type d | while read bundle; do
           echo "Found bundle: $bundle"
           cp -R "$bundle" "ClaudeCodeMonitor.app/Contents/Resources/"
         done


### PR DESCRIPTION
## Summary
v0.1.8でアプリが起動できない問題を修正

## 問題の原因
ユニバーサルバイナリのビルド方法を変更した際に、リソースバンドルが正しくアプリバンドルにコピーされていなかったため、アプリが起動できなくなっていました。

## 修正内容
- リソースバンドルの検索パスを`*arm64*/release/*.bundle`に限定
- arm64ビルドからのみリソースをコピーすることで、重複を防ぎつつ確実にリソースを含める
- リソースは全アーキテクチャで同一のため、この方法で問題ありません

## Test plan
- [x] release.ymlの修正を確認
- [ ] 新しいリリースワークフローでビルドされたアプリが正常に起動することを確認

## 関連
- #27 で導入したユニバーサルバイナリビルドの改善が原因でした

🤖 Generated with [Claude Code](https://claude.ai/code)