### PR TITLE
feat: タグベースのバージョン管理システムを実装

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,17 +38,17 @@ jobs:
           echo "type=patch" >> $GITHUB_OUTPUT
         fi
     
-    - name: Bump version
+    - name: Determine next version
       id: version
       run: |
         VERSION_TYPE="${{ steps.version_type.outputs.type }}"
-        echo "Bumping version: $VERSION_TYPE"
+        echo "Determining next version: $VERSION_TYPE"
         
-        # Run bump script and capture output
-        ./scripts/bump-version.sh "$VERSION_TYPE"
+        # Get next version from git tags
+        ./scripts/get-next-version.sh "$VERSION_TYPE"
         
-        # Read the new version
-        NEW_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" Info.plist)
+        # Capture output for GitHub Actions
+        NEW_VERSION=$(./scripts/get-next-version.sh "$VERSION_TYPE" 2>/dev/null)
         echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
         echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
     
@@ -195,8 +195,10 @@ jobs:
         # Copy executable
         cp "$EXECUTABLE_PATH" "ClaudeCodeMonitor.app/Contents/MacOS/"
         
-        # Copy Info.plist (version already updated by bump script)
+        # Copy Info.plist and update version
         cp Info.plist "ClaudeCodeMonitor.app/Contents/"
+        /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${{ steps.version.outputs.version }}" "ClaudeCodeMonitor.app/Contents/Info.plist"
+        /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${{ steps.version.outputs.version }}" "ClaudeCodeMonitor.app/Contents/Info.plist"
         
         # Copy resource bundles from arm64 build (they are identical across architectures)
         echo "Looking for resource bundles..."

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
     <key>CFBundleExecutable</key>
     <string>ClaudeCodeMonitor</string>
     <key>CFBundleVersion</key>
-    <string>0.1.7</string>
+    <string>0.0.0-dev</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.7</string>
+    <string>0.0.0-dev</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>CFBundlePackageType</key>

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Build script for local development
+# This creates a development build with the current git state
+
+echo "🔨 Building Claude Code Monitor (Development Version)"
+
+# Get version information
+if git describe --exact-match --tags HEAD 2>/dev/null; then
+  # Building from a tag
+  VERSION=$(git describe --exact-match --tags HEAD | sed 's/^v//')
+  echo "Building from tag: v$VERSION"
+else
+  # Development build
+  COMMIT=$(git rev-parse --short HEAD)
+  BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  VERSION="0.0.0-dev+$BRANCH.$COMMIT"
+  echo "Development build: $VERSION"
+fi
+
+# Build the app
+echo "Building Swift package..."
+swift build -c release
+
+# Find the executable
+EXECUTABLE_PATH=$(find .build -name ClaudeCodeMonitor -type f -perm +111 | grep -v '.dSYM' | grep release | head -1)
+
+if [ ! -f "$EXECUTABLE_PATH" ]; then
+  echo "❌ Failed to find executable"
+  exit 1
+fi
+
+echo "✅ Binary built at: $EXECUTABLE_PATH"
+
+# Create app bundle
+echo "Creating app bundle..."
+rm -rf ClaudeCodeMonitor.app
+mkdir -p "ClaudeCodeMonitor.app/Contents/MacOS"
+mkdir -p "ClaudeCodeMonitor.app/Contents/Resources"
+
+# Copy executable
+cp "$EXECUTABLE_PATH" "ClaudeCodeMonitor.app/Contents/MacOS/"
+
+# Copy and update Info.plist
+cp Info.plist "ClaudeCodeMonitor.app/Contents/"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "ClaudeCodeMonitor.app/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION" "ClaudeCodeMonitor.app/Contents/Info.plist"
+
+# Copy resource bundles
+echo "Looking for resource bundles..."
+find .build -name "*.bundle" -type d | grep release | while read bundle; do
+  echo "Found bundle: $bundle"
+  cp -R "$bundle" "ClaudeCodeMonitor.app/Contents/Resources/"
+done
+
+# Ad-hoc sign for local use
+echo "Signing app bundle..."
+codesign --force --deep --sign - "ClaudeCodeMonitor.app"
+
+echo "✅ Build complete!"
+echo ""
+echo "To run the app:"
+echo "  open ClaudeCodeMonitor.app"
+echo ""
+echo "Version: $VERSION"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,57 +1,11 @@
 #!/bin/bash
 
-# Bump version script for Claude Code Monitor
-# Usage: ./bump-version.sh [patch|minor|major]
+# DEPRECATED: This script is kept for backward compatibility
+# Use get-next-version.sh instead for tag-based versioning
 
+echo "WARNING: bump-version.sh is deprecated. Use get-next-version.sh instead." >&2
+echo "This script will be removed in a future version." >&2
+
+# For backward compatibility, just call get-next-version.sh
 VERSION_TYPE=${1:-patch}
-
-# Get current version from Info.plist
-CURRENT_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" Info.plist)
-
-if [ -z "$CURRENT_VERSION" ]; then
-  echo "Error: Could not read current version from Info.plist"
-  exit 1
-fi
-
-echo "Current version: $CURRENT_VERSION"
-
-# Parse version components
-IFS='.' read -r -a VERSION_PARTS <<< "$CURRENT_VERSION"
-MAJOR="${VERSION_PARTS[0]}"
-MINOR="${VERSION_PARTS[1]}"
-PATCH="${VERSION_PARTS[2]}"
-
-# Increment version based on type
-case "$VERSION_TYPE" in
-  major)
-    MAJOR=$((MAJOR + 1))
-    MINOR=0
-    PATCH=0
-    ;;
-  minor)
-    MINOR=$((MINOR + 1))
-    PATCH=0
-    ;;
-  patch)
-    PATCH=$((PATCH + 1))
-    ;;
-  *)
-    echo "Error: Invalid version type. Use 'patch', 'minor', or 'major'"
-    exit 1
-    ;;
-esac
-
-NEW_VERSION="$MAJOR.$MINOR.$PATCH"
-echo "New version: $NEW_VERSION"
-
-# Update Info.plist
-/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $NEW_VERSION" Info.plist
-/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $NEW_VERSION" Info.plist
-
-
-echo "✅ Version updated to $NEW_VERSION"
-
-# Output for GitHub Actions
-if [ -n "$GITHUB_OUTPUT" ]; then
-  echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
-fi
+exec "$(dirname "$0")/get-next-version.sh" "$VERSION_TYPE"

--- a/scripts/get-next-version.sh
+++ b/scripts/get-next-version.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Get next version based on git tags
+# Usage: ./get-next-version.sh [patch|minor|major]
+
+VERSION_TYPE=${1:-patch}
+
+# Get the latest tag (semantic version tags only)
+LATEST_TAG=$(git tag -l "v*.*.*" | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -1)
+
+if [ -z "$LATEST_TAG" ]; then
+  # No tags found, start with v0.1.0
+  echo "No semantic version tags found, starting with v0.1.0" >&2
+  CURRENT_VERSION="0.0.0"
+else
+  # Extract version from tag (remove 'v' prefix)
+  CURRENT_VERSION=${LATEST_TAG#v}
+  echo "Latest tag: $LATEST_TAG (version: $CURRENT_VERSION)" >&2
+fi
+
+# Parse version components
+IFS='.' read -r -a VERSION_PARTS <<< "$CURRENT_VERSION"
+MAJOR="${VERSION_PARTS[0]:-0}"
+MINOR="${VERSION_PARTS[1]:-0}"
+PATCH="${VERSION_PARTS[2]:-0}"
+
+# Increment version based on type
+case "$VERSION_TYPE" in
+  major)
+    MAJOR=$((MAJOR + 1))
+    MINOR=0
+    PATCH=0
+    ;;
+  minor)
+    MINOR=$((MINOR + 1))
+    PATCH=0
+    ;;
+  patch)
+    PATCH=$((PATCH + 1))
+    ;;
+  *)
+    echo "Error: Invalid version type. Use 'patch', 'minor', or 'major'" >&2
+    exit 1
+    ;;
+esac
+
+NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+NEW_TAG="v$NEW_VERSION"
+
+# Check if the new tag already exists
+if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
+  echo "Error: Tag $NEW_TAG already exists!" >&2
+  echo "Current tags:" >&2
+  git tag -l "v*.*.*" | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -5 >&2
+  exit 1
+fi
+
+# Output the new version (without 'v' prefix for version, with 'v' for tag)
+echo "Next version: $NEW_VERSION" >&2
+echo "Next tag: $NEW_TAG" >&2
+
+# Output for scripts (clean output)
+if [ -n "$GITHUB_OUTPUT" ]; then
+  echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+  echo "tag=$NEW_TAG" >> $GITHUB_OUTPUT
+else
+  # For local testing, output just the version
+  echo "$NEW_VERSION"
+fi


### PR DESCRIPTION
## Summary
Gitタグを単一の真実の源とする新しいバージョン管理システムを導入し、バージョンの不整合問題を根本的に解決します。

## 背景
- PR #27, #28でリリース時にタグとInfo.plistのバージョンが不一致になる問題が発生
- v0.1.8タグが既に存在するのに、Info.plistが0.1.7のままだったため、リリースが失敗

## 解決策
mainブランチのInfo.plistは開発版を示す`0.0.0-dev`に固定し、リリース時にGitタグから動的にバージョンを決定する方式に変更。

## 変更内容

### 1. 新スクリプト: `scripts/get-next-version.sh`
- Gitタグから次のバージョンを計算
- タグの重複チェック機能
- セマンティックバージョニング対応（patch/minor/major）

### 2. Info.plistの変更
- バージョンを`0.0.0-dev`に固定
- リリース時に動的に正しいバージョンが注入される

### 3. release.ymlの更新
- `bump-version.sh`の代わりに`get-next-version.sh`を使用
- ビルド時にInfo.plistに正しいバージョンを注入

### 4. bump-version.shの非推奨化
- 後方互換性のため残すが、内部で`get-next-version.sh`を呼び出す

### 5. 新スクリプト: `scripts/build-local.sh`
- ローカル開発用のビルドスクリプト
- タグがある場合はそのバージョン、なければ開発版として識別

## メリット
- ✅ バージョンの真実の源がGitタグ一つに統一
- ✅ タグとInfo.plistの不整合が発生しない
- ✅ 開発版と正式版が明確に区別される
- ✅ リリースの失敗を防ぐ

## Test plan
- [x] `get-next-version.sh`の動作確認（0.1.9が正しく計算される）
- [x] ローカルビルドスクリプトの動作確認
- [ ] リリースワークフローでの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)