### PR TITLE
fix: Bundle.moduleのパス解決問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,86 +188,10 @@ jobs:
         rm certificate.p12
     
     # Build the app
-    - name: Build universal binary
-      run: |
-        echo "🔨 Building universal binary..."
-        
-        # Build for arm64
-        echo "Building for arm64..."
-        swift build -c release --arch arm64
-        
-        # Build for x86_64
-        echo "Building for x86_64..."
-        swift build -c release --arch x86_64
-        
-        # Find the arm64 executable
-        ARM64_PATH=$(find .build -path "*arm64*/release/ClaudeCodeMonitor" -type f | head -1)
-        X86_64_PATH=$(find .build -path "*x86_64*/release/ClaudeCodeMonitor" -type f | head -1)
-        
-        if [ -z "$ARM64_PATH" ] || [ -z "$X86_64_PATH" ]; then
-          echo "❌ Failed to find one or both architectures"
-          echo "ARM64: $ARM64_PATH"
-          echo "X86_64: $X86_64_PATH"
-          find .build -name ClaudeCodeMonitor -type f
-          exit 1
-        fi
-        
-        echo "ARM64 binary: $ARM64_PATH"
-        echo "X86_64 binary: $X86_64_PATH"
-        
-        # Create universal binary
-        UNIVERSAL_PATH=".build/universal/release/ClaudeCodeMonitor"
-        mkdir -p .build/universal/release
-        lipo -create -output "$UNIVERSAL_PATH" "$ARM64_PATH" "$X86_64_PATH"
-        
-        if [ -f "$UNIVERSAL_PATH" ]; then
-          echo "✅ Universal binary created at: $UNIVERSAL_PATH"
-          file "$UNIVERSAL_PATH"
-          lipo -info "$UNIVERSAL_PATH"
-          echo "EXECUTABLE_PATH=$UNIVERSAL_PATH" >> $GITHUB_ENV
-        else
-          echo "❌ Failed to create universal binary"
-          exit 1
-        fi
-    
-    # Create app bundle
     - name: Create app bundle
       run: |
-        # Create app structure
-        mkdir -p "ClaudeCodeMonitor.app/Contents/MacOS"
-        mkdir -p "ClaudeCodeMonitor.app/Contents/Resources"
-        
-        # Copy executable
-        cp "$EXECUTABLE_PATH" "ClaudeCodeMonitor.app/Contents/MacOS/"
-        
-        # Copy Info.plist and update version
-        cp Info.plist "ClaudeCodeMonitor.app/Contents/"
-        /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${{ steps.version.outputs.version }}" "ClaudeCodeMonitor.app/Contents/Info.plist"
-        /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${{ steps.version.outputs.version }}" "ClaudeCodeMonitor.app/Contents/Info.plist"
-        
-        # Copy resource bundles from arm64 build (they are identical across architectures)
-        echo "Looking for resource bundles..."
-        find .build -path "*arm64*/release/*.bundle" -type d | while read bundle; do
-          echo "Found bundle: $bundle"
-          cp -R "$bundle" "ClaudeCodeMonitor.app/Contents/Resources/"
-        done
-        
-        # Verify app structure
-        echo "=== App bundle structure ==="
-        echo "Root directory (should only contain Contents):"
-        ls -la "ClaudeCodeMonitor.app/"
-        echo ""
-        echo "Contents directory:"
-        ls -la "ClaudeCodeMonitor.app/Contents/"
-        echo ""
-        echo "MacOS directory:"
-        ls -la "ClaudeCodeMonitor.app/Contents/MacOS/"
-        echo ""
-        echo "Resources directory:"
-        ls -la "ClaudeCodeMonitor.app/Contents/Resources/" || echo "No Resources directory"
-        echo ""
-        echo "Executable info:"
-        file "ClaudeCodeMonitor.app/Contents/MacOS/ClaudeCodeMonitor"
+        # Use the create-app-bundle.sh script
+        ./scripts/create-app-bundle.sh "${{ steps.version.outputs.version }}"
     
     # Sign the app
     - name: Sign app bundle

--- a/Sources/ClaudeUsageMonitor/Localization.swift
+++ b/Sources/ClaudeUsageMonitor/Localization.swift
@@ -1,6 +1,39 @@
 import Foundation
 import SwiftUI
 
+// MARK: - Resource Bundle Helper
+private struct ResourceBundle {
+    static let current: Bundle = {
+        let bundleName = "ClaudeCodeMonitor_ClaudeCodeMonitor.bundle"
+        
+        // Try different possible locations in order of preference
+        let candidates = [
+            // 1. macOS app bundle structure (production)
+            Bundle.main.bundleURL
+                .appendingPathComponent("Contents/Resources/\(bundleName)"),
+            
+            // 2. Same directory as executable (SwiftPM default behavior)
+            Bundle.main.bundleURL
+                .appendingPathComponent(bundleName),
+            
+            // 3. Parent directory (some development scenarios)
+            Bundle.main.bundleURL
+                .deletingLastPathComponent()
+                .appendingPathComponent(bundleName)
+        ]
+        
+        // Try each candidate path
+        for candidate in candidates {
+            if let bundle = Bundle(url: candidate) {
+                return bundle
+            }
+        }
+        
+        // Fallback: use the auto-generated Bundle.module
+        return Bundle.module
+    }()
+}
+
 // MARK: - Localization Helper
 extension String {
     var localized: String {
@@ -10,15 +43,16 @@ extension String {
         }
         
         let languageCode = LanguageSettings.shared.effectiveLanguageCode()
+        let resourceBundle = ResourceBundle.current
         
         // Try to get the bundle for the specific language
-        if let path = Bundle.module.path(forResource: languageCode, ofType: "lproj"),
+        if let path = resourceBundle.path(forResource: languageCode, ofType: "lproj"),
            let bundle = Bundle(path: path) {
             return NSLocalizedString(self, bundle: bundle, comment: "")
         }
         
         // Fallback to module bundle
-        return NSLocalizedString(self, bundle: .module, comment: "")
+        return NSLocalizedString(self, bundle: resourceBundle, comment: "")
     }
     
     func localized(with arguments: CVarArg...) -> String {
@@ -28,15 +62,16 @@ extension String {
         }
         
         let languageCode = LanguageSettings.shared.effectiveLanguageCode()
+        let resourceBundle = ResourceBundle.current
         
         // Try to get the bundle for the specific language
-        if let path = Bundle.module.path(forResource: languageCode, ofType: "lproj"),
+        if let path = resourceBundle.path(forResource: languageCode, ofType: "lproj"),
            let bundle = Bundle(path: path) {
             return String(format: NSLocalizedString(self, bundle: bundle, comment: ""), arguments: arguments)
         }
         
         // Fallback to module bundle
-        return String(format: NSLocalizedString(self, bundle: .module, comment: ""), arguments: arguments)
+        return String(format: NSLocalizedString(self, bundle: resourceBundle, comment: ""), arguments: arguments)
     }
 }
 

--- a/scripts/create-app-bundle.sh
+++ b/scripts/create-app-bundle.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Create macOS app bundle from Swift executable
+# Usage: ./scripts/create-app-bundle.sh <version>
+
+set -euo pipefail
+
+VERSION="${1:-0.0.0-dev}"
+
+echo "🔨 Creating macOS app bundle for version $VERSION"
+
+# Build universal binary
+echo "Building universal binary..."
+
+# Build for arm64
+echo "  Building for arm64..."
+swift build -c release --arch arm64
+
+# Build for x86_64
+echo "  Building for x86_64..."
+swift build -c release --arch x86_64
+
+# Find the executables
+ARM64_PATH=$(find .build -path "*arm64*/release/ClaudeCodeMonitor" -type f | head -1)
+X86_64_PATH=$(find .build -path "*x86_64*/release/ClaudeCodeMonitor" -type f | head -1)
+
+if [ -z "$ARM64_PATH" ] || [ -z "$X86_64_PATH" ]; then
+    echo "❌ Failed to find one or both architectures"
+    echo "  ARM64: $ARM64_PATH"
+    echo "  X86_64: $X86_64_PATH"
+    exit 1
+fi
+
+echo "  Found ARM64 binary: $ARM64_PATH"
+echo "  Found X86_64 binary: $X86_64_PATH"
+
+# Create universal binary
+UNIVERSAL_DIR=".build/universal/release"
+UNIVERSAL_PATH="$UNIVERSAL_DIR/ClaudeCodeMonitor"
+mkdir -p "$UNIVERSAL_DIR"
+
+echo "  Creating universal binary..."
+lipo -create -output "$UNIVERSAL_PATH" "$ARM64_PATH" "$X86_64_PATH"
+
+if [ ! -f "$UNIVERSAL_PATH" ]; then
+    echo "❌ Failed to create universal binary"
+    exit 1
+fi
+
+echo "✅ Universal binary created"
+file "$UNIVERSAL_PATH"
+lipo -info "$UNIVERSAL_PATH"
+
+# Create app bundle structure
+echo ""
+echo "Creating app bundle..."
+APP_PATH="ClaudeCodeMonitor.app"
+
+# Clean existing app bundle
+if [ -d "$APP_PATH" ]; then
+    echo "  Removing existing app bundle..."
+    rm -rf "$APP_PATH"
+fi
+
+# Create directory structure
+mkdir -p "$APP_PATH/Contents/"{MacOS,Resources}
+
+# Copy executable
+echo "  Copying executable..."
+cp "$UNIVERSAL_PATH" "$APP_PATH/Contents/MacOS/ClaudeCodeMonitor"
+
+# Copy Info.plist and update version
+echo "  Copying Info.plist..."
+cp Info.plist "$APP_PATH/Contents/Info.plist"
+
+echo "  Updating version to $VERSION..."
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$APP_PATH/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION" "$APP_PATH/Contents/Info.plist"
+
+# Copy resource bundles from arm64 build (they are identical across architectures)
+echo "  Looking for resource bundles..."
+find .build -path "*arm64*/release/*.bundle" -type d | while read bundle; do
+    echo "    Found bundle: $(basename "$bundle")"
+    cp -R "$bundle" "$APP_PATH/Contents/Resources/"
+done
+
+# Verify app structure
+echo ""
+echo "Verifying app bundle structure..."
+echo "  App bundle root:"
+ls -la "$APP_PATH/"
+echo ""
+echo "  Contents directory:"
+ls -la "$APP_PATH/Contents/"
+echo ""
+echo "  MacOS directory:"
+ls -la "$APP_PATH/Contents/MacOS/"
+echo ""
+echo "  Resources directory:"
+ls -la "$APP_PATH/Contents/Resources/" || echo "  No Resources directory"
+echo ""
+echo "  Executable info:"
+file "$APP_PATH/Contents/MacOS/ClaudeCodeMonitor"
+
+echo ""
+echo "✅ App bundle created successfully: $APP_PATH"
+echo "   Version: $VERSION"


### PR DESCRIPTION
## 概要
v0.1.9でアプリが起動時に以下のエラーで失敗する問題を修正します：
```
Fatal error: could not load resource bundle: from /ClaudeCodeMonitor.app/ClaudeCodeMonitor_ClaudeCodeMonitor.bundle
```

## 問題の原因
SwiftPMが生成する`resource_bundle_accessor.swift`は、実行ファイルと同じディレクトリにリソースバンドルがあることを期待していますが、macOSアプリでは`Contents/Resources`に配置する必要があります。

この問題は、[v20250625-120023からv0.1.9への変更](https://github.com/K9i-0/ClaudeCodeMonitor/compare/v20250625-120023...v0.1.9)で導入されたバグです。タグベースのバージョン管理システムへの移行時に、リソースバンドルのパス解決が正しく動作しなくなりました。

## 解決策
1. **ResourceBundleヘルパーの実装**
   - `Localization.swift`に複数のパスを試すヘルパーを追加
   - macOSアプリ構造（Contents/Resources）を優先的に確認
   - フォールバックとして既存のBundle.moduleも使用

2. **ビルドプロセスの改善**
   - アプリバンドル作成処理を`scripts/create-app-bundle.sh`に分離
   - GitHub Actionsワークフローを簡素化
   - メンテナンス性の向上

## テスト結果
- [x] ローカルビルドで起動確認
- [x] リソース（ローカライゼーション）が正しく読み込まれることを確認
- [ ] GitHub Actionsでのビルド確認（マージ後）

## 関連Issue
- #31 のマージ後に発覚した問題

🤖 Generated with [Claude Code](https://claude.ai/code)