### PR TITLE
feat: Add start at login setting

### DIFF
--- a/Sources/ClaudeUsageMonitor/Localization.swift
+++ b/Sources/ClaudeUsageMonitor/Localization.swift
@@ -167,6 +167,7 @@ struct L10n {
         static var languageSettings: String { "settings.languageSettings".localized }
         static var useSystemLanguage: String { "settings.useSystemLanguage".localized }
         static var selectLanguage: String { "settings.selectLanguage".localized }
+        static var startAtLogin: String { "settings.startAtLogin".localized }
     }
     
     struct Language {

--- a/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
@@ -81,6 +81,7 @@
 "settings.languageSettings" = "Language";
 "settings.useSystemLanguage" = "Use system language";
 "settings.selectLanguage" = "Select language";
+"settings.startAtLogin" = "Start at login";
 
 // Language options
 "language.system" = "System";

--- a/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
@@ -81,6 +81,7 @@
 "settings.languageSettings" = "言語";
 "settings.useSystemLanguage" = "システムの言語を使用";
 "settings.selectLanguage" = "言語を選択";
+"settings.startAtLogin" = "ログイン時に起動";
 
 // Language options
 "language.system" = "システム";

--- a/Sources/ClaudeUsageMonitor/SettingsTabView.swift
+++ b/Sources/ClaudeUsageMonitor/SettingsTabView.swift
@@ -1,8 +1,10 @@
 import SwiftUI
+import ServiceManagement
 
 struct SettingsTabView: View {
     @EnvironmentObject var monitor: UsageMonitor
     @StateObject private var languageSettings = LanguageSettings.shared
+    @State private var isLoginItemEnabled = false
     // @State private var notificationEnabled = Bundle.main.bundleIdentifier != nil ? NotificationManager.shared.isNotificationEnabled : false
     
     let plans = [
@@ -117,7 +119,62 @@ struct SettingsTabView: View {
             }
             */
             
+            Divider()
+            
+            // Login item settings section
+            VStack(alignment: .leading, spacing: 12) {
+                Toggle(isOn: $isLoginItemEnabled) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "power")
+                            .font(.system(size: 14))
+                            .foregroundStyle(isLoginItemEnabled ? .blue : .secondary)
+                        Text(L10n.Settings.startAtLogin)
+                            .font(.system(size: 14))
+                    }
+                }
+                .toggleStyle(SwitchToggleStyle(tint: .blue))
+                .onChange(of: isLoginItemEnabled) { newValue in
+                    updateLoginItemStatus(newValue)
+                }
+            }
+            
             Spacer()
+        }
+        .onAppear {
+            checkLoginItemStatus()
+        }
+    }
+    
+    private func checkLoginItemStatus() {
+        if #available(macOS 13.0, *) {
+            let status = SMAppService.mainApp.status
+            isLoginItemEnabled = (status == .enabled)
+        }
+    }
+    
+    private func updateLoginItemStatus(_ enable: Bool) {
+        if #available(macOS 13.0, *) {
+            do {
+                if enable {
+                    if SMAppService.mainApp.status == .enabled {
+                        print("Already registered as login item")
+                    } else {
+                        try SMAppService.mainApp.register()
+                        print("Successfully registered as login item")
+                    }
+                } else {
+                    if SMAppService.mainApp.status == .notRegistered {
+                        print("Not registered as login item")
+                    } else {
+                        try SMAppService.mainApp.unregister()
+                        print("Successfully unregistered as login item")
+                    }
+                }
+            } catch {
+                print("Failed to update login item status: \(error)")
+                // Revert the toggle state on error
+                checkLoginItemStatus()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- ServiceManagementフレームワークを使用してログイン時の自動起動機能を実装
- 設定タブに「ログイン時に起動」トグルを追加
- SMAppServiceを使用してログイン項目の登録/解除を管理

## Changes
- ローカライゼーションファイルに `startAtLogin` 文字列を追加（英語・日本語）
- `L10n.Settings` 構造体に `startAtLogin` プロパティを追加
- `SettingsTabView` に自動起動設定セクションを実装
  - ServiceManagementフレームワークをインポート
  - ログイン項目の状態を管理する `@State` 変数を追加
  - OS設定との同期を行う `checkLoginItemStatus()` メソッドを実装
  - 登録/解除を行う `updateLoginItemStatus(_:)` メソッドを実装

## Test plan
- [x] アプリをビルドして実行
- [x] 設定タブで「ログイン時に起動」をオンにする
- [x] システム設定のログイン項目にClaudeCodeMonitorが追加されることを確認
- [x] トグルをオフにしてログイン項目から削除されることを確認
- [x] エラーハンドリングが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)