### PR TITLE
fix: GitHub ActionsでNode.jsバイナリをバンドルするように修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,44 @@ jobs:
         
         rm certificate.p12
     
+    # Download Node.js binaries for bundling
+    - name: Download Node.js binaries
+      run: |
+        echo "📦 Downloading Node.js binaries..."
+        mkdir -p Resources/node
+        
+        # Download Node.js v20.18.2 (LTS)
+        NODE_VERSION="v20.18.2"
+        
+        # Download arm64 binary
+        echo "  Downloading arm64 binary..."
+        curl -L -o node-arm64.tar.xz "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-darwin-arm64.tar.xz"
+        
+        # Download x64 binary
+        echo "  Downloading x64 binary..."
+        curl -L -o node-x64.tar.xz "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-darwin-x64.tar.xz"
+        
+        # Extract binaries
+        echo "  Extracting binaries..."
+        tar -xf node-arm64.tar.xz
+        tar -xf node-x64.tar.xz
+        
+        # Create universal binary
+        echo "  Creating universal binary..."
+        lipo -create -output Resources/node/node \
+          "node-${NODE_VERSION}-darwin-arm64/bin/node" \
+          "node-${NODE_VERSION}-darwin-x64/bin/node"
+        
+        # Verify universal binary
+        echo "  Verifying universal binary..."
+        file Resources/node/node
+        lipo -info Resources/node/node
+        
+        # Clean up
+        rm -rf node-*.tar.xz node-${NODE_VERSION}-*
+        
+        echo "✅ Node.js universal binary created"
+    
     # Build the app
     - name: Create app bundle
       run: |


### PR DESCRIPTION
## 概要
リリースv0.1.11でDMGサイズが1.8MBと異常に小さく、Node.jsバイナリがバンドルされていない問題を修正します。

## 問題の詳細
- v0.1.11のDMG: **1.8MB** （Node.jsが含まれていない）
- 期待されるサイズ: **約50MB以上** （Node.jsバイナリ込み）

## 修正内容
GitHub Actionsのrelease.ymlに以下の処理を追加：

1. Node.js v20.18.2 (LTS) のバイナリをダウンロード
   - arm64版とx64版の両方
2. `lipo`コマンドでユニバーサルバイナリを作成
3. `Resources/node/node`として配置
4. その後`create-app-bundle.sh`を実行

## 確認事項
- [x] Node.jsバイナリのダウンロードURL確認
- [x] ユニバーサルバイナリ作成コマンド確認
- [x] create-app-bundle.shでNode.jsがコピーされることを確認

## 関連Issue
- #35 - DMGの容量がおかしい（Node.jsがバンドルできていない）

🤖 Generated with [Claude Code](https://claude.ai/code)