### PR TITLE
fix: Node.jsのJIT実行に必要なエンタイトルメントを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,6 +292,22 @@ jobs:
         # Use the create-app-bundle.sh script
         ./scripts/create-app-bundle.sh "${{ steps.version.outputs.version }}"
     
+    # Sign Node.js binary with entitlements
+    - name: Sign Node.js binary
+      if: steps.check_signing.outputs.has_signing_cert == 'true'
+      run: |
+        echo "🔏 Signing Node.js binary with entitlements..."
+        
+        # Sign Node.js with entitlements
+        codesign --force --strict \
+          --options runtime \
+          --entitlements node.entitlements \
+          --sign "$CERT_NAME" \
+          --timestamp \
+          "ClaudeCodeMonitor.app/Contents/Resources/node/node"
+        
+        echo "✅ Node.js binary signed"
+        
     # Sign the app
     - name: Sign app bundle
       if: steps.check_signing.outputs.has_signing_cert == 'true'
@@ -324,9 +340,9 @@ jobs:
         echo "=== App bundle root after cleanup ==="
         ls -la "ClaudeCodeMonitor.app/"
         
-        # Try signing
+        # Try signing (without --deep to preserve Node.js signature)
         echo "=== Attempting to sign ==="
-        codesign --force --deep --strict \
+        codesign --force --strict \
           --options runtime \
           --entitlements ClaudeCodeMonitor.entitlements \
           --sign "$CERT_NAME" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,20 @@ npm start  # Runs on http://127.0.0.1:3456
 # Open in Xcode (recommended for development)
 open Package.swift
 # Then Build (⌘B) and Run (⌘R) in Xcode
+
+# Local testing with Node.js bundled (App Sandbox mode)
+./scripts/test-local-with-node.sh
+# This script:
+# 1. Downloads Node.js binaries (if not already present)
+# 2. Creates universal binary
+# 3. Builds the app with --skip-signing flag
+# 4. Signs Node.js with entitlements
+# 5. Signs the app with ad-hoc certificate
+# Then run: open ClaudeCodeMonitor.app
+
+# Clean up processes if needed
+killall ClaudeCodeMonitor 2>/dev/null || true
+ps aux | grep -E "node.*server" | grep -v grep | awk '{print $2}' | xargs kill 2>/dev/null || true
 ```
 
 ## Architecture
@@ -51,6 +65,12 @@ open Package.swift
 - When App Sandbox is enabled, the local server (http://127.0.0.1:3456) is **required**
 - Direct command execution (npx) is not possible with App Sandbox
 - Network entitlements allow localhost connections only
+
+### Data Access (App Sandbox)
+- Uses NSOpenPanel for user to grant access to ~/.claude directory
+- Security-scoped bookmarks persist access across app launches
+- No temporary-exception entitlements (App Store compliant)
+- ClaudeDataAccessManager handles folder selection and bookmark management
 
 ### Key Components
 

--- a/ClaudeCodeMonitor.entitlements
+++ b/ClaudeCodeMonitor.entitlements
@@ -16,7 +16,8 @@
     <true/>
     <key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
     <array>
-        <string>/.config/claude.ai/</string>
+        <string>/.claude/</string>
+        <string>/.config/claude/</string>
     </array>
 </dict>
 </plist>

--- a/ClaudeCodeMonitor.entitlements
+++ b/ClaudeCodeMonitor.entitlements
@@ -14,10 +14,5 @@
     <true/>
     <key>com.apple.security.files.bookmarks.app-scope</key>
     <true/>
-    <key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
-    <array>
-        <string>/.claude/</string>
-        <string>/.config/claude/</string>
-    </array>
 </dict>
 </plist>

--- a/ClaudeCodeMonitor.entitlements
+++ b/ClaudeCodeMonitor.entitlements
@@ -10,5 +10,13 @@
     <true/>
     <key>com.apple.security.inherit</key>
     <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+    <key>com.apple.security.files.bookmarks.app-scope</key>
+    <true/>
+    <key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+    <array>
+        <string>/.config/claude.ai/</string>
+    </array>
 </dict>
 </plist>

--- a/Sources/ClaudeUsageMonitor/AppDelegate.swift
+++ b/Sources/ClaudeUsageMonitor/AppDelegate.swift
@@ -209,7 +209,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     @MainActor
-    private func showPopover() {
+    func showPopover() {
         if let button = statusItem.button {
             // Refresh data when opening popover
             usageMonitor.fetchUsageData()
@@ -221,6 +221,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func closePopover() {
         popover.performClose(nil)
         eventMonitor?.stop()
+    }
+    
+    func pauseEventMonitor() {
+        eventMonitor?.stop()
+    }
+    
+    func resumeEventMonitor() {
+        if popover.isShown {
+            eventMonitor?.start()
+        }
     }
     
     func applicationWillTerminate(_ notification: Notification) {

--- a/Sources/ClaudeUsageMonitor/AppDelegate.swift
+++ b/Sources/ClaudeUsageMonitor/AppDelegate.swift
@@ -8,9 +8,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var popover: NSPopover!
     private var eventMonitor: EventMonitor?
     private var usageMonitor: UsageMonitor!
+    private var dataAccessManager: ClaudeDataAccessManager!
     
     func applicationDidFinishLaunching(_ notification: Notification) {
-        // Start the local server first
+        // Initialize data access manager
+        dataAccessManager = ClaudeDataAccessManager()
+        
+        // Pass claude path to server manager if available
+        if dataAccessManager.hasAccess {
+            ServerManager.shared.claudePath = dataAccessManager.claudePath
+        }
+        
+        // Start the local server
         ServerManager.shared.checkAndStartServer()
         
         usageMonitor = UsageMonitor()
@@ -49,7 +58,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         popover.contentSize = NSSize(width: 380, height: 480)
         popover.behavior = .transient
         popover.animates = true
-        popover.contentViewController = NSHostingController(rootView: ContentView().environmentObject(usageMonitor))
+        popover.contentViewController = NSHostingController(
+            rootView: ContentView()
+                .environmentObject(usageMonitor)
+                .environmentObject(dataAccessManager)
+        )
         
         // Monitor for clicks outside the popover
         eventMonitor = EventMonitor(mask: [.leftMouseDown, .rightMouseDown]) { [weak self] event in
@@ -66,6 +79,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.updateStatusBarTitle()
+            }
+            .store(in: &cancellables)
+        
+        // Observe data access changes
+        dataAccessManager.$hasAccess
+            .receive(on: DispatchQueue.main)
+            .dropFirst() // Skip initial value
+            .sink { [weak self] hasAccess in
+                if hasAccess {
+                    // Update server with claude path
+                    ServerManager.shared.claudePath = self?.dataAccessManager.claudePath
+                    
+                    // Restart server if needed
+                    if ServerManager.shared.isServerRunning {
+                        ServerManager.shared.stopServer()
+                        ServerManager.shared.checkAndStartServer()
+                    }
+                    
+                    // Fetch data
+                    self?.usageMonitor.fetchUsageData()
+                }
             }
             .store(in: &cancellables)
     }

--- a/Sources/ClaudeUsageMonitor/AppDelegate.swift
+++ b/Sources/ClaudeUsageMonitor/AppDelegate.swift
@@ -17,6 +17,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Pass claude path to server manager if available
         if dataAccessManager.hasAccess {
             print("[AppDelegate] Data access already available, path: \(dataAccessManager.claudePath ?? "nil")")
+            NSLog("[AppDelegate] Data access already available, path: %@", dataAccessManager.claudePath ?? "nil")
             ServerManager.shared.claudePath = dataAccessManager.claudePath
             
             // Start the local server with path

--- a/Sources/ClaudeUsageMonitor/AppDelegate.swift
+++ b/Sources/ClaudeUsageMonitor/AppDelegate.swift
@@ -16,11 +16,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Pass claude path to server manager if available
         if dataAccessManager.hasAccess {
+            print("[AppDelegate] Data access already available, path: \(dataAccessManager.claudePath ?? "nil")")
             ServerManager.shared.claudePath = dataAccessManager.claudePath
+            
+            // Start the local server with path
+            ServerManager.shared.checkAndStartServer()
+        } else {
+            print("[AppDelegate] No data access yet, server will start after folder selection")
+            // Don't start server yet - will start after user selects folder
         }
-        
-        // Start the local server
-        ServerManager.shared.checkAndStartServer()
         
         usageMonitor = UsageMonitor()
         

--- a/Sources/ClaudeUsageMonitor/AppDelegate.swift
+++ b/Sources/ClaudeUsageMonitor/AppDelegate.swift
@@ -20,7 +20,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             ServerManager.shared.claudePath = dataAccessManager.claudePath
             
             // Start the local server with path
-            ServerManager.shared.checkAndStartServer()
+            Task {
+                await ServerManager.shared.checkAndStartServer()
+            }
         } else {
             print("[AppDelegate] No data access yet, server will start after folder selection")
             // Don't start server yet - will start after user selects folder
@@ -98,7 +100,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     // Restart server if needed
                     if ServerManager.shared.isServerRunning {
                         ServerManager.shared.stopServer()
-                        ServerManager.shared.checkAndStartServer()
+                        Task {
+                            await ServerManager.shared.checkAndStartServer()
+                        }
                     }
                     
                     // Fetch data

--- a/Sources/ClaudeUsageMonitor/AppDelegate.swift
+++ b/Sources/ClaudeUsageMonitor/AppDelegate.swift
@@ -218,7 +218,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
     
-    private func closePopover() {
+    func closePopover() {
         popover.performClose(nil)
         eventMonitor?.stop()
     }

--- a/Sources/ClaudeUsageMonitor/ClaudeDataAccessManager.swift
+++ b/Sources/ClaudeUsageMonitor/ClaudeDataAccessManager.swift
@@ -1,0 +1,134 @@
+import Foundation
+import AppKit
+
+@MainActor
+class ClaudeDataAccessManager: ObservableObject {
+    @Published var hasAccess = false
+    @Published var claudePath: String?
+    
+    private let bookmarkKey = "ClaudeDataFolderBookmark"
+    
+    init() {
+        checkExistingAccess()
+    }
+    
+    /// Check if we have existing access via bookmark
+    func checkExistingAccess() {
+        guard let bookmarkData = UserDefaults.standard.data(forKey: bookmarkKey) else {
+            print("[ClaudeDataAccess] No existing bookmark found")
+            return
+        }
+        
+        do {
+            var isStale = false
+            let url = try URL(resolvingBookmarkData: bookmarkData,
+                            options: .withSecurityScope,
+                            relativeTo: nil,
+                            bookmarkDataIsStale: &isStale)
+            
+            if isStale {
+                print("[ClaudeDataAccess] Bookmark is stale, need to request access again")
+                hasAccess = false
+                return
+            }
+            
+            // Start accessing the security-scoped resource
+            if url.startAccessingSecurityScopedResource() {
+                claudePath = url.path
+                hasAccess = true
+                print("[ClaudeDataAccess] Successfully accessed Claude data at: \(url.path)")
+                
+                // We'll stop accessing when the app terminates
+                // In a real app, you might want to manage this more carefully
+            } else {
+                print("[ClaudeDataAccess] Failed to access security-scoped resource")
+                hasAccess = false
+            }
+        } catch {
+            print("[ClaudeDataAccess] Error resolving bookmark: \(error)")
+            hasAccess = false
+        }
+    }
+    
+    /// Request access to Claude data folder
+    func requestAccess() async -> Bool {
+        let openPanel = NSOpenPanel()
+        openPanel.title = L10n.selectClaudeDataFolder
+        openPanel.message = L10n.claudeDataFolderMessage
+        openPanel.prompt = L10n.select
+        openPanel.canChooseFiles = false
+        openPanel.canChooseDirectories = true
+        openPanel.canCreateDirectories = false
+        openPanel.showsHiddenFiles = true
+        
+        // Set default directory to home
+        openPanel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+        
+        let response = await openPanel.begin()
+        
+        guard response == .OK,
+              let url = openPanel.url else {
+            print("[ClaudeDataAccess] User cancelled folder selection")
+            return false
+        }
+        
+        // Verify this is a Claude data folder by checking for projects subdirectory
+        let projectsURL = url.appendingPathComponent("projects")
+        let fileManager = FileManager.default
+        
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: projectsURL.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            print("[ClaudeDataAccess] Selected folder doesn't contain 'projects' subdirectory")
+            // Show error alert
+            await showError(message: L10n.invalidClaudeFolder)
+            return false
+        }
+        
+        // Create security-scoped bookmark
+        do {
+            let bookmarkData = try url.bookmarkData(options: .withSecurityScope,
+                                                   includingResourceValuesForKeys: nil,
+                                                   relativeTo: nil)
+            
+            // Save bookmark to UserDefaults
+            UserDefaults.standard.set(bookmarkData, forKey: bookmarkKey)
+            
+            // Start accessing the resource
+            if url.startAccessingSecurityScopedResource() {
+                claudePath = url.path
+                hasAccess = true
+                print("[ClaudeDataAccess] Successfully saved access to: \(url.path)")
+                return true
+            } else {
+                print("[ClaudeDataAccess] Failed to start accessing security-scoped resource")
+                return false
+            }
+        } catch {
+            print("[ClaudeDataAccess] Error creating bookmark: \(error)")
+            await showError(message: L10n.failedToSaveAccess)
+            return false
+        }
+    }
+    
+    /// Show error alert
+    private func showError(message: String) async {
+        let alert = NSAlert()
+        alert.messageText = L10n.error
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: L10n.ok)
+        
+        await alert.beginSheetModal(for: NSApp.keyWindow!)
+    }
+    
+    /// Reset access (for testing or if user wants to change folder)
+    func resetAccess() {
+        UserDefaults.standard.removeObject(forKey: bookmarkKey)
+        if let path = claudePath {
+            URL(fileURLWithPath: path).stopAccessingSecurityScopedResource()
+        }
+        claudePath = nil
+        hasAccess = false
+    }
+}

--- a/Sources/ClaudeUsageMonitor/ClaudeDataAccessManager.swift
+++ b/Sources/ClaudeUsageMonitor/ClaudeDataAccessManager.swift
@@ -9,11 +9,33 @@ class ClaudeDataAccessManager: ObservableObject {
     private let bookmarkKey = "ClaudeDataFolderBookmark"
     
     init() {
+        print("[ClaudeDataAccess] Initializing...")
         checkExistingAccess()
+        print("[ClaudeDataAccess] Initial hasAccess: \(hasAccess), claudePath: \(claudePath ?? "nil")")
     }
     
-    /// Check if we have existing access via bookmark
+    /// Check if we have existing access via saved path or bookmark
     func checkExistingAccess() {
+        // First try to load saved path
+        if let savedPath = UserDefaults.standard.string(forKey: "claudeDataPath") {
+            print("[ClaudeDataAccess] Found saved path: \(savedPath)")
+            // Verify the path still exists and has projects subdirectory
+            let url = URL(fileURLWithPath: savedPath)
+            let projectsURL = url.appendingPathComponent("projects")
+            
+            if FileManager.default.fileExists(atPath: projectsURL.path) {
+                claudePath = savedPath
+                hasAccess = true
+                print("[ClaudeDataAccess] Path is valid, access restored")
+                return
+            } else {
+                print("[ClaudeDataAccess] Saved path no longer valid")
+                // Clear invalid path
+                UserDefaults.standard.removeObject(forKey: "claudeDataPath")
+            }
+        }
+        
+        // Legacy bookmark support
         guard let bookmarkData = UserDefaults.standard.data(forKey: bookmarkKey) else {
             print("[ClaudeDataAccess] No existing bookmark found")
             return
@@ -54,9 +76,28 @@ class ClaudeDataAccessManager: ObservableObject {
     func requestAccess() async -> Bool {
         print("[ClaudeDataAccess] Requesting folder access...")
         
+        // Pause event monitor to prevent popover from closing
+        await MainActor.run {
+            if let appDelegate = NSApp.delegate as? AppDelegate {
+                appDelegate.pauseEventMonitor()
+            }
+        }
+        
         return await withCheckedContinuation { continuation in
             FolderAccessHelper.requestFolderAccess { [weak self] url in
-                guard let self = self, let url = url else {
+                guard let self = self else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                
+                // Resume event monitor after dialog is closed
+                Task { @MainActor in
+                    if let appDelegate = NSApp.delegate as? AppDelegate {
+                        appDelegate.resumeEventMonitor()
+                    }
+                }
+                
+                guard let url = url else {
                     print("[ClaudeDataAccess] User cancelled folder selection")
                     continuation.resume(returning: false)
                     return
@@ -81,44 +122,47 @@ class ClaudeDataAccessManager: ObservableObject {
         var isDirectory: ObjCBool = false
         guard fileManager.fileExists(atPath: projectsURL.path, isDirectory: &isDirectory),
               isDirectory.boolValue else {
-            print("[ClaudeDataAccess] Selected folder doesn't contain 'projects' subdirectory")
-            // Show error alert
-            await showError(message: L10n.invalidClaudeFolder)
+            print("[ClaudeDataAccess] Selected folder doesn't contain 'projects' subdirectory: \(url.path)")
+            print("[ClaudeDataAccess] Looking for: \(projectsURL.path)")
+            // Show error alert with more detail
+            let errorMessage = """
+            \(L10n.invalidClaudeFolder)
+            
+            Selected: \(url.path)
+            Expected: ~/.claude (with projects subdirectory)
+            """
+            await showError(message: errorMessage)
             return false
         }
         
         // Start accessing the resource BEFORE creating bookmark
+        // Note: startAccessingSecurityScopedResource returns false for non-security-scoped URLs,
+        // which is normal for user-selected folders via NSOpenPanel
         let startedAccess = url.startAccessingSecurityScopedResource()
         print("[ClaudeDataAccess] Started security-scoped access: \(startedAccess)")
+        print("[ClaudeDataAccess] URL: \(url.path)")
         
-        guard startedAccess else {
-            print("[ClaudeDataAccess] Failed to start accessing security-scoped resource")
-            await showError(message: L10n.failedToSaveAccess)
-            return false
+        // Don't fail if startAccessingSecurityScopedResource returns false
+        // as it's expected for regular file URLs from NSOpenPanel
+        
+        // For App Sandbox, we'll simply save the path and rely on the server
+        // to access the files with CLAUDE_CONFIG_DIR environment variable
+        claudePath = url.path
+        hasAccess = true
+        
+        // Save the path to UserDefaults (not as bookmark, just as string)
+        UserDefaults.standard.set(url.path, forKey: "claudeDataPath")
+        UserDefaults.standard.synchronize()
+        
+        print("[ClaudeDataAccess] Successfully saved path: \(url.path)")
+        print("[ClaudeDataAccess] hasAccess is now: \(hasAccess)")
+        
+        // Stop accessing if we started it
+        if startedAccess {
+            url.stopAccessingSecurityScopedResource()
         }
         
-        // Create security-scoped bookmark while access is active
-        do {
-            let bookmarkData = try url.bookmarkData(options: .withSecurityScope,
-                                                   includingResourceValuesForKeys: nil,
-                                                   relativeTo: nil)
-            
-            // Save bookmark to UserDefaults
-            UserDefaults.standard.set(bookmarkData, forKey: bookmarkKey)
-            UserDefaults.standard.synchronize() // Force save
-            
-            claudePath = url.path
-            hasAccess = true
-            print("[ClaudeDataAccess] Successfully saved access to: \(url.path)")
-            print("[ClaudeDataAccess] hasAccess is now: \(hasAccess)")
-            
-            // Don't stop accessing here - keep it active for the session
-            return true
-        } catch {
-            print("[ClaudeDataAccess] Error creating bookmark: \(error)")
-            await showError(message: L10n.failedToSaveAccess)
-            return false
-        }
+        return true
     }
     
     /// Show error alert
@@ -136,7 +180,11 @@ class ClaudeDataAccessManager: ObservableObject {
     
     /// Reset access (for testing or if user wants to change folder)
     func resetAccess() {
+        print("[ClaudeDataAccess] Resetting access...")
         UserDefaults.standard.removeObject(forKey: bookmarkKey)
+        UserDefaults.standard.removeObject(forKey: "claudeDataPath")
+        UserDefaults.standard.synchronize()
+        
         if let path = claudePath {
             URL(fileURLWithPath: path).stopAccessingSecurityScopedResource()
         }

--- a/Sources/ClaudeUsageMonitor/ClaudeDataAccessManager.swift
+++ b/Sources/ClaudeUsageMonitor/ClaudeDataAccessManager.swift
@@ -54,27 +54,25 @@ class ClaudeDataAccessManager: ObservableObject {
     func requestAccess() async -> Bool {
         print("[ClaudeDataAccess] Requesting folder access...")
         
-        let openPanel = NSOpenPanel()
-        openPanel.title = L10n.selectClaudeDataFolder
-        openPanel.message = L10n.claudeDataFolderMessage
-        openPanel.prompt = L10n.select
-        openPanel.canChooseFiles = false
-        openPanel.canChooseDirectories = true
-        openPanel.canCreateDirectories = false
-        openPanel.showsHiddenFiles = true
-        
-        // Set default directory to home
-        openPanel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
-        
-        let response = await openPanel.begin()
-        
-        guard response == .OK,
-              let url = openPanel.url else {
-            print("[ClaudeDataAccess] User cancelled folder selection")
-            return false
+        return await withCheckedContinuation { continuation in
+            FolderAccessHelper.requestFolderAccess { [weak self] url in
+                guard let self = self, let url = url else {
+                    print("[ClaudeDataAccess] User cancelled folder selection")
+                    continuation.resume(returning: false)
+                    return
+                }
+                
+                print("[ClaudeDataAccess] User selected: \(url.path)")
+                
+                Task {
+                    let success = await self.processSelectedFolder(url)
+                    continuation.resume(returning: success)
+                }
+            }
         }
-        
-        print("[ClaudeDataAccess] User selected: \(url.path)")
+    }
+    
+    private func processSelectedFolder(_ url: URL) async -> Bool {
         
         // Verify this is a Claude data folder by checking for projects subdirectory
         let projectsURL = url.appendingPathComponent("projects")
@@ -125,13 +123,15 @@ class ClaudeDataAccessManager: ObservableObject {
     
     /// Show error alert
     private func showError(message: String) async {
-        let alert = NSAlert()
-        alert.messageText = L10n.error
-        alert.informativeText = message
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: L10n.ok)
-        
-        await alert.beginSheetModal(for: NSApp.keyWindow!)
+        await MainActor.run {
+            let alert = NSAlert()
+            alert.messageText = L10n.error
+            alert.informativeText = message
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: L10n.ok)
+            
+            alert.runModal()
+        }
     }
     
     /// Reset access (for testing or if user wants to change folder)

--- a/Sources/ClaudeUsageMonitor/ClaudeDataAccessManager.swift
+++ b/Sources/ClaudeUsageMonitor/ClaudeDataAccessManager.swift
@@ -7,6 +7,7 @@ class ClaudeDataAccessManager: ObservableObject {
     @Published var claudePath: String?
     
     private let bookmarkKey = "ClaudeDataFolderBookmark"
+    private var securityScopedResourceURL: URL?
     
     init() {
         print("[ClaudeDataAccess] Initializing...")
@@ -56,12 +57,14 @@ class ClaudeDataAccessManager: ObservableObject {
             
             // Start accessing the security-scoped resource
             if url.startAccessingSecurityScopedResource() {
+                // Stop any previous access
+                stopAccessingSecurityScopedResource()
+                
+                // Track the new resource
+                securityScopedResourceURL = url
                 claudePath = url.path
                 hasAccess = true
                 print("[ClaudeDataAccess] Successfully accessed Claude data at: \(url.path)")
-                
-                // We'll stop accessing when the app terminates
-                // In a real app, you might want to manage this more carefully
             } else {
                 print("[ClaudeDataAccess] Failed to access security-scoped resource")
                 hasAccess = false
@@ -115,20 +118,41 @@ class ClaudeDataAccessManager: ObservableObject {
     
     private func processSelectedFolder(_ url: URL) async -> Bool {
         
+        // Resolve any symbolic links to get the real path
+        let resolvedURL = url.resolvingSymlinksInPath()
+        print("[ClaudeDataAccess] Original path: \(url.path)")
+        print("[ClaudeDataAccess] Resolved path: \(resolvedURL.path)")
+        
+        // Security check: Ensure the resolved path is within the user's home directory
+        let homeDirectory = FileManager.default.homeDirectoryForCurrentUser
+        if !resolvedURL.path.hasPrefix(homeDirectory.path) {
+            print("[ClaudeDataAccess] Security warning: Selected path is outside home directory")
+            let errorMessage = """
+            Security Error: The selected folder is outside your home directory.
+            
+            Selected: \(url.path)
+            Resolved to: \(resolvedURL.path)
+            
+            Please select a folder within your home directory.
+            """
+            await showError(message: errorMessage)
+            return false
+        }
+        
         // Verify this is a Claude data folder by checking for projects subdirectory
-        let projectsURL = url.appendingPathComponent("projects")
+        let projectsURL = resolvedURL.appendingPathComponent("projects")
         let fileManager = FileManager.default
         
         var isDirectory: ObjCBool = false
         guard fileManager.fileExists(atPath: projectsURL.path, isDirectory: &isDirectory),
               isDirectory.boolValue else {
-            print("[ClaudeDataAccess] Selected folder doesn't contain 'projects' subdirectory: \(url.path)")
+            print("[ClaudeDataAccess] Selected folder doesn't contain 'projects' subdirectory: \(resolvedURL.path)")
             print("[ClaudeDataAccess] Looking for: \(projectsURL.path)")
             // Show error alert with more detail
             let errorMessage = """
             \(L10n.invalidClaudeFolder)
             
-            Selected: \(url.path)
+            Selected: \(resolvedURL.path)
             Expected: ~/.claude (with projects subdirectory)
             """
             await showError(message: errorMessage)
@@ -138,28 +162,29 @@ class ClaudeDataAccessManager: ObservableObject {
         // Start accessing the resource BEFORE creating bookmark
         // Note: startAccessingSecurityScopedResource returns false for non-security-scoped URLs,
         // which is normal for user-selected folders via NSOpenPanel
-        let startedAccess = url.startAccessingSecurityScopedResource()
+        let startedAccess = resolvedURL.startAccessingSecurityScopedResource()
         print("[ClaudeDataAccess] Started security-scoped access: \(startedAccess)")
-        print("[ClaudeDataAccess] URL: \(url.path)")
+        print("[ClaudeDataAccess] URL: \(resolvedURL.path)")
         
         // Don't fail if startAccessingSecurityScopedResource returns false
         // as it's expected for regular file URLs from NSOpenPanel
         
         // For App Sandbox, we'll simply save the path and rely on the server
         // to access the files with CLAUDE_CONFIG_DIR environment variable
-        claudePath = url.path
+        claudePath = resolvedURL.path
         hasAccess = true
         
-        // Save the path to UserDefaults (not as bookmark, just as string)
-        UserDefaults.standard.set(url.path, forKey: "claudeDataPath")
+        // Save the resolved path to UserDefaults (not as bookmark, just as string)
+        UserDefaults.standard.set(resolvedURL.path, forKey: "claudeDataPath")
         UserDefaults.standard.synchronize()
         
-        print("[ClaudeDataAccess] Successfully saved path: \(url.path)")
+        print("[ClaudeDataAccess] Successfully saved path: \(resolvedURL.path)")
         print("[ClaudeDataAccess] hasAccess is now: \(hasAccess)")
         
-        // Stop accessing if we started it
+        // We don't need to keep the security-scoped resource access active
+        // since we're using the path via environment variable
         if startedAccess {
-            url.stopAccessingSecurityScopedResource()
+            resolvedURL.stopAccessingSecurityScopedResource()
         }
         
         return true
@@ -185,10 +210,24 @@ class ClaudeDataAccessManager: ObservableObject {
         UserDefaults.standard.removeObject(forKey: "claudeDataPath")
         UserDefaults.standard.synchronize()
         
-        if let path = claudePath {
-            URL(fileURLWithPath: path).stopAccessingSecurityScopedResource()
-        }
+        stopAccessingSecurityScopedResource()
         claudePath = nil
         hasAccess = false
+    }
+    
+    /// Stop accessing any security-scoped resource
+    private func stopAccessingSecurityScopedResource() {
+        if let url = securityScopedResourceURL {
+            url.stopAccessingSecurityScopedResource()
+            securityScopedResourceURL = nil
+            print("[ClaudeDataAccess] Stopped accessing security-scoped resource")
+        }
+    }
+    
+    deinit {
+        // Ensure we release any security-scoped resources on deallocation
+        if let url = securityScopedResourceURL {
+            url.stopAccessingSecurityScopedResource()
+        }
     }
 }

--- a/Sources/ClaudeUsageMonitor/ClaudeDataAccessManager.swift
+++ b/Sources/ClaudeUsageMonitor/ClaudeDataAccessManager.swift
@@ -52,6 +52,8 @@ class ClaudeDataAccessManager: ObservableObject {
     
     /// Request access to Claude data folder
     func requestAccess() async -> Bool {
+        print("[ClaudeDataAccess] Requesting folder access...")
+        
         let openPanel = NSOpenPanel()
         openPanel.title = L10n.selectClaudeDataFolder
         openPanel.message = L10n.claudeDataFolderMessage
@@ -72,6 +74,8 @@ class ClaudeDataAccessManager: ObservableObject {
             return false
         }
         
+        print("[ClaudeDataAccess] User selected: \(url.path)")
+        
         // Verify this is a Claude data folder by checking for projects subdirectory
         let projectsURL = url.appendingPathComponent("projects")
         let fileManager = FileManager.default
@@ -85,7 +89,17 @@ class ClaudeDataAccessManager: ObservableObject {
             return false
         }
         
-        // Create security-scoped bookmark
+        // Start accessing the resource BEFORE creating bookmark
+        let startedAccess = url.startAccessingSecurityScopedResource()
+        print("[ClaudeDataAccess] Started security-scoped access: \(startedAccess)")
+        
+        guard startedAccess else {
+            print("[ClaudeDataAccess] Failed to start accessing security-scoped resource")
+            await showError(message: L10n.failedToSaveAccess)
+            return false
+        }
+        
+        // Create security-scoped bookmark while access is active
         do {
             let bookmarkData = try url.bookmarkData(options: .withSecurityScope,
                                                    includingResourceValuesForKeys: nil,
@@ -93,17 +107,15 @@ class ClaudeDataAccessManager: ObservableObject {
             
             // Save bookmark to UserDefaults
             UserDefaults.standard.set(bookmarkData, forKey: bookmarkKey)
+            UserDefaults.standard.synchronize() // Force save
             
-            // Start accessing the resource
-            if url.startAccessingSecurityScopedResource() {
-                claudePath = url.path
-                hasAccess = true
-                print("[ClaudeDataAccess] Successfully saved access to: \(url.path)")
-                return true
-            } else {
-                print("[ClaudeDataAccess] Failed to start accessing security-scoped resource")
-                return false
-            }
+            claudePath = url.path
+            hasAccess = true
+            print("[ClaudeDataAccess] Successfully saved access to: \(url.path)")
+            print("[ClaudeDataAccess] hasAccess is now: \(hasAccess)")
+            
+            // Don't stop accessing here - keep it active for the session
+            return true
         } catch {
             print("[ClaudeDataAccess] Error creating bookmark: \(error)")
             await showError(message: L10n.failedToSaveAccess)

--- a/Sources/ClaudeUsageMonitor/ClaudePathHelper.swift
+++ b/Sources/ClaudeUsageMonitor/ClaudePathHelper.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct ClaudePathHelper {
+    /// Get the expected Claude data paths in order of preference
+    static func getExpectedPaths() -> [URL] {
+        let homeURL = FileManager.default.homeDirectoryForCurrentUser
+        return [
+            homeURL.appendingPathComponent(".claude"),
+            homeURL.appendingPathComponent(".config/claude")
+        ]
+    }
+    
+    /// Find the first existing Claude data path
+    static func findExistingClaudePath() -> URL? {
+        let paths = getExpectedPaths()
+        let fileManager = FileManager.default
+        
+        for path in paths {
+            let projectsPath = path.appendingPathComponent("projects")
+            var isDirectory: ObjCBool = false
+            if fileManager.fileExists(atPath: projectsPath.path, isDirectory: &isDirectory),
+               isDirectory.boolValue {
+                return path
+            }
+        }
+        
+        return nil
+    }
+}

--- a/Sources/ClaudeUsageMonitor/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/ContentView.swift
@@ -2,11 +2,21 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject var monitor: UsageMonitor
+    @EnvironmentObject var dataAccessManager: ClaudeDataAccessManager
     @State private var selectedTab = 0
     @State private var isRefreshing = false
     @Environment(\.colorScheme) var colorScheme
     
     var body: some View {
+        if !dataAccessManager.hasAccess {
+            DataAccessView()
+                .frame(width: 380, height: 300)
+        } else {
+            mainContent
+        }
+    }
+    
+    var mainContent: some View {
         ZStack {
             // Background with visual effect
             VisualEffectBlur(material: .popover, blendingMode: .behindWindow)

--- a/Sources/ClaudeUsageMonitor/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/ContentView.swift
@@ -537,13 +537,13 @@ struct UsageDetailView: View {
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(.secondary)
                 
-                ForEach(modelBreakdowns.sorted(by: { $0.cost > $1.cost }), id: \.modelName) { breakdown in
+                ForEach(modelBreakdowns.sorted(by: { $0.actualCost > $1.actualCost }), id: \.modelName) { breakdown in
                     HStack {
                         Text(formatModelName(breakdown.modelName))
                             .font(.system(size: 12))
                         Spacer()
                         VStack(alignment: .trailing, spacing: 2) {
-                            Text(monitor.formatCost(breakdown.cost))
+                            Text(monitor.formatCost(breakdown.actualCost))
                                 .font(.system(size: 12, weight: .medium))
                             Text("\(monitor.formatTokens(breakdown.inputTokens + breakdown.outputTokens)) tokens")
                                 .font(.system(size: 10))

--- a/Sources/ClaudeUsageMonitor/DataAccessView.swift
+++ b/Sources/ClaudeUsageMonitor/DataAccessView.swift
@@ -27,18 +27,25 @@ struct DataAccessView: View {
                     isRequesting = false
                     
                     if success {
+                        print("[DataAccessView] Access granted, updating server...")
+                        
                         // Update server with new path
                         ServerManager.shared.claudePath = dataAccessManager.claudePath
                         
-                        // Restart server if it's running
+                        // Stop server first if running
                         if ServerManager.shared.isServerRunning {
+                            print("[DataAccessView] Stopping existing server...")
                             ServerManager.shared.stopServer()
-                            ServerManager.shared.checkAndStartServer()
-                        } else {
-                            ServerManager.shared.checkAndStartServer()
                         }
                         
-                        // Fetch data
+                        // Start server with new path
+                        print("[DataAccessView] Starting server with new path...")
+                        ServerManager.shared.checkAndStartServer()
+                        
+                        // Wait a bit for server to start before fetching data
+                        try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+                        
+                        print("[DataAccessView] Fetching usage data...")
                         monitor.fetchUsageData()
                     }
                 }

--- a/Sources/ClaudeUsageMonitor/DataAccessView.swift
+++ b/Sources/ClaudeUsageMonitor/DataAccessView.swift
@@ -11,10 +11,10 @@ struct DataAccessView: View {
                 .font(.system(size: 50))
                 .foregroundStyle(.blue)
             
-            Text("Claude Data Access Required")
+            Text("Permission Required")
                 .font(.headline)
             
-            Text("To monitor your Claude usage, this app needs access to your Claude data folder.")
+            Text("Grant access to monitor your Claude usage")
                 .font(.caption)
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
@@ -24,15 +24,7 @@ struct DataAccessView: View {
                 print("[DataAccessView] Button clicked")
                 isRequesting = true
                 
-                // Close popover temporarily to show file dialog
-                if let appDelegate = NSApp.delegate as? AppDelegate {
-                    appDelegate.closePopover()
-                }
-                
                 Task { @MainActor in
-                    // Small delay to ensure popover is closed
-                    try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
-                    
                     let success = await dataAccessManager.requestAccess()
                     print("[DataAccessView] Request completed with success: \(success)")
                     isRequesting = false
@@ -69,7 +61,7 @@ struct DataAccessView: View {
                     } else {
                         Image(systemName: "folder.fill")
                     }
-                    Text("Select Claude Data Folder")
+                    Text("Grant Access to Claude Data")
                 }
                 .frame(minWidth: 200)
             }

--- a/Sources/ClaudeUsageMonitor/DataAccessView.swift
+++ b/Sources/ClaudeUsageMonitor/DataAccessView.swift
@@ -4,6 +4,8 @@ struct DataAccessView: View {
     @EnvironmentObject var dataAccessManager: ClaudeDataAccessManager
     @EnvironmentObject var monitor: UsageMonitor
     @State private var isRequesting = false
+    @State private var errorMessage: String?
+    @State private var showingError = false
     
     var body: some View {
         VStack(spacing: 20) {
@@ -27,7 +29,6 @@ struct DataAccessView: View {
                 Task { @MainActor in
                     let success = await dataAccessManager.requestAccess()
                     print("[DataAccessView] Request completed with success: \(success)")
-                    isRequesting = false
                     
                     if success {
                         print("[DataAccessView] Access granted, updating server...")
@@ -43,14 +44,26 @@ struct DataAccessView: View {
                         
                         // Start server with new path
                         print("[DataAccessView] Starting server with new path...")
-                        ServerManager.shared.checkAndStartServer()
+                        let serverStarted = await ServerManager.shared.checkAndStartServer()
                         
-                        // Wait a bit for server to start before fetching data
-                        try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
-                        
-                        print("[DataAccessView] Fetching usage data...")
-                        monitor.fetchUsageData()
+                        if serverStarted {
+                            // Wait a bit for server to stabilize
+                            let waitTime = UInt64(Constants.Timing.dataAccessWaitTime * 1_000_000_000)
+                            try? await Task.sleep(nanoseconds: waitTime)
+                            
+                            print("[DataAccessView] Fetching usage data...")
+                            monitor.fetchUsageData()
+                        } else {
+                            errorMessage = "Failed to start the monitoring server. Please try again."
+                            showingError = true
+                        }
+                    } else {
+                        // Access request was cancelled or failed
+                        errorMessage = "Access to Claude data folder was not granted."
+                        showingError = true
                     }
+                    
+                    isRequesting = false
                 }
             }) {
                 HStack {
@@ -74,5 +87,12 @@ struct DataAccessView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()
+        .alert("Error", isPresented: $showingError) {
+            Button("OK") {
+                errorMessage = nil
+            }
+        } message: {
+            Text(errorMessage ?? "An unknown error occurred")
+        }
     }
 }

--- a/Sources/ClaudeUsageMonitor/DataAccessView.swift
+++ b/Sources/ClaudeUsageMonitor/DataAccessView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct DataAccessView: View {
+    @EnvironmentObject var dataAccessManager: ClaudeDataAccessManager
+    @EnvironmentObject var monitor: UsageMonitor
+    @State private var isRequesting = false
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "folder.badge.questionmark")
+                .font(.system(size: 50))
+                .foregroundStyle(.blue)
+            
+            Text("Claude Data Access Required")
+                .font(.headline)
+            
+            Text("To monitor your Claude usage, this app needs access to your Claude data folder.")
+                .font(.caption)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal)
+            
+            Button(action: {
+                Task {
+                    isRequesting = true
+                    let success = await dataAccessManager.requestAccess()
+                    isRequesting = false
+                    
+                    if success {
+                        // Update server with new path
+                        ServerManager.shared.claudePath = dataAccessManager.claudePath
+                        
+                        // Restart server if it's running
+                        if ServerManager.shared.isServerRunning {
+                            ServerManager.shared.stopServer()
+                            ServerManager.shared.checkAndStartServer()
+                        } else {
+                            ServerManager.shared.checkAndStartServer()
+                        }
+                        
+                        // Fetch data
+                        monitor.fetchUsageData()
+                    }
+                }
+            }) {
+                HStack {
+                    if isRequesting {
+                        ProgressView()
+                            .scaleEffect(0.8)
+                            .frame(width: 16, height: 16)
+                    } else {
+                        Image(systemName: "folder.fill")
+                    }
+                    Text("Select Claude Data Folder")
+                }
+                .frame(minWidth: 200)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isRequesting)
+            
+            Text("Typically located at ~/.claude")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}

--- a/Sources/ClaudeUsageMonitor/DataAccessView.swift
+++ b/Sources/ClaudeUsageMonitor/DataAccessView.swift
@@ -21,9 +21,20 @@ struct DataAccessView: View {
                 .padding(.horizontal)
             
             Button(action: {
-                Task {
-                    isRequesting = true
+                print("[DataAccessView] Button clicked")
+                isRequesting = true
+                
+                // Close popover temporarily to show file dialog
+                if let appDelegate = NSApp.delegate as? AppDelegate {
+                    appDelegate.closePopover()
+                }
+                
+                Task { @MainActor in
+                    // Small delay to ensure popover is closed
+                    try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+                    
                     let success = await dataAccessManager.requestAccess()
+                    print("[DataAccessView] Request completed with success: \(success)")
                     isRequesting = false
                     
                     if success {

--- a/Sources/ClaudeUsageMonitor/FolderAccessHelper.swift
+++ b/Sources/ClaudeUsageMonitor/FolderAccessHelper.swift
@@ -1,0 +1,31 @@
+import Foundation
+import AppKit
+
+@MainActor
+class FolderAccessHelper {
+    static func requestFolderAccess(completion: @escaping (URL?) -> Void) {
+        let openPanel = NSOpenPanel()
+        openPanel.title = L10n.selectClaudeDataFolder
+        openPanel.message = L10n.claudeDataFolderMessage
+        openPanel.prompt = L10n.select
+        openPanel.canChooseFiles = false
+        openPanel.canChooseDirectories = true
+        openPanel.canCreateDirectories = false
+        openPanel.showsHiddenFiles = true
+        
+        // Set default directory to home
+        openPanel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+        
+        // Make sure panel is key and front
+        openPanel.makeKeyAndOrderFront(nil)
+        openPanel.level = .modalPanel
+        
+        openPanel.begin { response in
+            if response == .OK {
+                completion(openPanel.url)
+            } else {
+                completion(nil)
+            }
+        }
+    }
+}

--- a/Sources/ClaudeUsageMonitor/FolderAccessHelper.swift
+++ b/Sources/ClaudeUsageMonitor/FolderAccessHelper.swift
@@ -41,28 +41,30 @@ class FolderAccessHelper {
         openPanel.makeKeyAndOrderFront(nil)
         openPanel.level = .modalPanel
         
-        // Use runModal for synchronous operation and better control
-        let response = openPanel.runModal()
-        
-        if response == .OK, let selectedURL = openPanel.url {
-            print("[FolderAccessHelper] User selected: \(selectedURL.path)")
-            
-            // Double-check that user selected the correct folder
-            if selectedURL.lastPathComponent == ".claude" {
-                completion(selectedURL)
-            } else {
-                // If user selected a parent directory, try to find .claude within it
-                let claudeInSelected = selectedURL.appendingPathComponent(".claude")
-                if FileManager.default.fileExists(atPath: claudeInSelected.path) {
-                    print("[FolderAccessHelper] Adjusting selection to: \(claudeInSelected.path)")
-                    completion(claudeInSelected)
+        // Use async begin to avoid blocking the UI
+        openPanel.begin { response in
+            Task { @MainActor in
+                if response == .OK, let selectedURL = openPanel.url {
+                    print("[FolderAccessHelper] User selected: \(selectedURL.path)")
+                    
+                    // Double-check that user selected the correct folder
+                    if selectedURL.lastPathComponent == ".claude" {
+                        completion(selectedURL)
+                    } else {
+                        // If user selected a parent directory, try to find .claude within it
+                        let claudeInSelected = selectedURL.appendingPathComponent(".claude")
+                        if FileManager.default.fileExists(atPath: claudeInSelected.path) {
+                            print("[FolderAccessHelper] Adjusting selection to: \(claudeInSelected.path)")
+                            completion(claudeInSelected)
+                        } else {
+                            completion(selectedURL)
+                        }
+                    }
                 } else {
-                    completion(selectedURL)
+                    print("[FolderAccessHelper] User cancelled")
+                    completion(nil)
                 }
             }
-        } else {
-            print("[FolderAccessHelper] User cancelled")
-            completion(nil)
         }
     }
 }

--- a/Sources/ClaudeUsageMonitor/FolderAccessHelper.swift
+++ b/Sources/ClaudeUsageMonitor/FolderAccessHelper.swift
@@ -13,19 +13,56 @@ class FolderAccessHelper {
         openPanel.canCreateDirectories = false
         openPanel.showsHiddenFiles = true
         
-        // Set default directory to home
-        openPanel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+        // Navigate directly to ~/.claude if it exists
+        let homeURL = FileManager.default.homeDirectoryForCurrentUser
+        let claudeURL = homeURL.appendingPathComponent(".claude")
+        
+        // Check if .claude exists and has projects subdirectory
+        let projectsURL = claudeURL.appendingPathComponent("projects")
+        var isDirectory: ObjCBool = false
+        
+        if FileManager.default.fileExists(atPath: claudeURL.path, isDirectory: &isDirectory),
+           isDirectory.boolValue,
+           FileManager.default.fileExists(atPath: projectsURL.path) {
+            openPanel.directoryURL = claudeURL
+            // Also pre-select it
+            openPanel.nameFieldStringValue = ".claude"
+        } else {
+            // If .claude doesn't exist, try .config/claude
+            let configClaudeURL = homeURL.appendingPathComponent(".config/claude")
+            if FileManager.default.fileExists(atPath: configClaudeURL.path) {
+                openPanel.directoryURL = configClaudeURL
+            } else {
+                openPanel.directoryURL = homeURL
+            }
+        }
         
         // Make sure panel is key and front
         openPanel.makeKeyAndOrderFront(nil)
         openPanel.level = .modalPanel
         
-        openPanel.begin { response in
-            if response == .OK {
-                completion(openPanel.url)
+        // Use runModal for synchronous operation and better control
+        let response = openPanel.runModal()
+        
+        if response == .OK, let selectedURL = openPanel.url {
+            print("[FolderAccessHelper] User selected: \(selectedURL.path)")
+            
+            // Double-check that user selected the correct folder
+            if selectedURL.lastPathComponent == ".claude" {
+                completion(selectedURL)
             } else {
-                completion(nil)
+                // If user selected a parent directory, try to find .claude within it
+                let claudeInSelected = selectedURL.appendingPathComponent(".claude")
+                if FileManager.default.fileExists(atPath: claudeInSelected.path) {
+                    print("[FolderAccessHelper] Adjusting selection to: \(claudeInSelected.path)")
+                    completion(claudeInSelected)
+                } else {
+                    completion(selectedURL)
+                }
             }
+        } else {
+            print("[FolderAccessHelper] User cancelled")
+            completion(nil)
         }
     }
 }

--- a/Sources/ClaudeUsageMonitor/Localization.swift
+++ b/Sources/ClaudeUsageMonitor/Localization.swift
@@ -218,4 +218,15 @@ struct L10n {
             return "status.usageFormat".localized(with: usage, cost, burnRate, timeRemaining)
         }
     }
+    
+    // General
+    static var ok: String { "ok".localized }
+    static var error: String { "error".localized }
+    static var select: String { "select".localized }
+    
+    // Claude Data Access
+    static var selectClaudeDataFolder: String { "selectClaudeDataFolder".localized }
+    static var claudeDataFolderMessage: String { "claudeDataFolderMessage".localized }
+    static var invalidClaudeFolder: String { "invalidClaudeFolder".localized }
+    static var failedToSaveAccess: String { "failedToSaveAccess".localized }
 }

--- a/Sources/ClaudeUsageMonitor/Models.swift
+++ b/Sources/ClaudeUsageMonitor/Models.swift
@@ -17,14 +17,6 @@ struct DailyUsage: Codable {
     let modelBreakdowns: [ModelBreakdown]
 }
 
-struct ModelBreakdown: Codable {
-    let modelName: String
-    let inputTokens: Int
-    let outputTokens: Int
-    let cacheCreationTokens: Int
-    let cacheReadTokens: Int
-    let cost: Double
-}
 
 struct Totals: Codable {
     let inputTokens: Int

--- a/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
@@ -105,3 +105,14 @@
 "notification.sent90Percent" = "90%% notification sent";
 "notification.sendError" = "Notification send error: %@";
 "notification.sessionResetError" = "Session reset notification error: %@";
+
+// General
+"ok" = "OK";
+"error" = "Error";
+"select" = "Select";
+
+// Claude Data Access
+"selectClaudeDataFolder" = "Select Claude Data Folder";
+"claudeDataFolderMessage" = "Please select your Claude data folder (usually ~/.claude).\n\nTo show hidden files, press Command+Shift+Period (.)";
+"invalidClaudeFolder" = "The selected folder doesn't appear to be a valid Claude data folder. Please make sure it contains a 'projects' subdirectory.";
+"failedToSaveAccess" = "Failed to save folder access. Please try again.";

--- a/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
@@ -109,10 +109,10 @@
 // General
 "ok" = "OK";
 "error" = "Error";
-"select" = "Select";
+"select" = "Grant Access";
 
 // Claude Data Access
-"selectClaudeDataFolder" = "Select Claude Data Folder";
-"claudeDataFolderMessage" = "Please select your Claude data folder (usually ~/.claude).\n\nTo show hidden files, press Command+Shift+Period (.)";
+"selectClaudeDataFolder" = "Grant Access to Claude Data";
+"claudeDataFolderMessage" = "This app needs access to your Claude data folder.\n\nThe folder should already be selected (~/.claude).\nJust click 'Grant Access' to continue.";
 "invalidClaudeFolder" = "The selected folder doesn't appear to be a valid Claude data folder. Please make sure it contains a 'projects' subdirectory.";
 "failedToSaveAccess" = "Failed to save folder access. Please try again.";

--- a/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
@@ -109,10 +109,10 @@
 // General
 "ok" = "OK";
 "error" = "エラー";
-"select" = "選択";
+"select" = "アクセスを許可";
 
 // Claude Data Access
-"selectClaudeDataFolder" = "Claudeデータフォルダを選択";
-"claudeDataFolderMessage" = "Claudeのデータフォルダを選択してください（通常は ~/.claude）。\n\n隠しファイルを表示するには、Command+Shift+ピリオド (.) を押してください。";
+"selectClaudeDataFolder" = "Claudeデータへのアクセスを許可";
+"claudeDataFolderMessage" = "このアプリはClaudeのデータフォルダへのアクセスが必要です。\n\nフォルダは既に選択されています（~/.claude）。\n「アクセスを許可」をクリックして続行してください。";
 "invalidClaudeFolder" = "選択されたフォルダは有効なClaudeデータフォルダではないようです。'projects'サブディレクトリが含まれていることを確認してください。";
 "failedToSaveAccess" = "フォルダアクセスの保存に失敗しました。もう一度お試しください。";

--- a/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
@@ -105,3 +105,14 @@
 "notification.sent90Percent" = "90%%通知を送信しました";
 "notification.sendError" = "通知送信エラー: %@";
 "notification.sessionResetError" = "セッションリセット通知エラー: %@";
+
+// General
+"ok" = "OK";
+"error" = "エラー";
+"select" = "選択";
+
+// Claude Data Access
+"selectClaudeDataFolder" = "Claudeデータフォルダを選択";
+"claudeDataFolderMessage" = "Claudeのデータフォルダを選択してください（通常は ~/.claude）。\n\n隠しファイルを表示するには、Command+Shift+ピリオド (.) を押してください。";
+"invalidClaudeFolder" = "選択されたフォルダは有効なClaudeデータフォルダではないようです。'projects'サブディレクトリが含まれていることを確認してください。";
+"failedToSaveAccess" = "フォルダアクセスの保存に失敗しました。もう一度お試しください。";

--- a/Sources/ClaudeUsageMonitor/ServerManager.swift
+++ b/Sources/ClaudeUsageMonitor/ServerManager.swift
@@ -7,6 +7,7 @@ class ServerManager: ObservableObject {
     private var serverProcess: Process?
     private let serverPort = 3456
     @Published var isServerRunning = false
+    var claudePath: String?
     
     private init() {}
     
@@ -109,14 +110,11 @@ class ServerManager: ObservableObject {
         var environment = ProcessInfo.processInfo.environment
         environment["PORT"] = "\(serverPort)"
         
-        // Set CLAUDE_CONFIG_DIR to help ccusage find data in App Sandbox
-        // Try multiple possible paths where Claude data might be stored
-        let possiblePaths = [
-            NSHomeDirectory() + "/.config/claude",
-            NSHomeDirectory() + "/.claude",
-            NSHomeDirectory() + "/Library/Application Support/Claude"
-        ]
-        environment["CLAUDE_CONFIG_DIR"] = possiblePaths.joined(separator: ",")
+        // Set CLAUDE_CONFIG_DIR if we have access to Claude data
+        if let claudePath = claudePath {
+            environment["CLAUDE_CONFIG_DIR"] = claudePath
+            print("[ServerManager] Setting CLAUDE_CONFIG_DIR to: \(claudePath)")
+        }
         
         process.environment = environment
         

--- a/Sources/ClaudeUsageMonitor/ServerManager.swift
+++ b/Sources/ClaudeUsageMonitor/ServerManager.swift
@@ -108,6 +108,16 @@ class ServerManager: ObservableObject {
         // Set up environment
         var environment = ProcessInfo.processInfo.environment
         environment["PORT"] = "\(serverPort)"
+        
+        // Set CLAUDE_CONFIG_DIR to help ccusage find data in App Sandbox
+        // Try multiple possible paths where Claude data might be stored
+        let possiblePaths = [
+            NSHomeDirectory() + "/.config/claude",
+            NSHomeDirectory() + "/.claude",
+            NSHomeDirectory() + "/Library/Application Support/Claude"
+        ]
+        environment["CLAUDE_CONFIG_DIR"] = possiblePaths.joined(separator: ",")
+        
         process.environment = environment
         
         // Redirect output

--- a/Sources/ClaudeUsageMonitor/ServerManager.swift
+++ b/Sources/ClaudeUsageMonitor/ServerManager.swift
@@ -101,8 +101,8 @@ class ServerManager: ObservableObject {
         }
         
         process.executableURL = URL(fileURLWithPath: node)
-        // Use server-fixed.js as specified in package.json
-        process.arguments = ["server-fixed.js"]
+        // Add --max-old-space-size to prevent memory issues in sandboxed environment
+        process.arguments = ["--max-old-space-size=128", "server.js"]
         process.currentDirectoryURL = URL(fileURLWithPath: validServerPath)
         
         // Set up environment

--- a/Sources/ClaudeUsageMonitor/ServerManager.swift
+++ b/Sources/ClaudeUsageMonitor/ServerManager.swift
@@ -44,12 +44,24 @@ class ServerManager: ObservableObject {
     
     private func startServer() async -> Bool {
         print("[ServerManager] Attempting to start server")
+        NSLog("[ServerManager] Attempting to start server")
         
         // First, try to find server in the app bundle (production)
         var serverPath: String?
+        print("[ServerManager] Bundle.main.bundlePath: \(Bundle.main.bundlePath)")
+        print("[ServerManager] Bundle.main.resourcePath: \(Bundle.main.resourcePath ?? "nil")")
+        
         if let bundledServerPath = Bundle.main.path(forResource: "server", ofType: nil) {
             serverPath = bundledServerPath
             print("[ServerManager] Using bundled server at: \(bundledServerPath)")
+            
+            // Verify server.js exists
+            let serverJsPath = (bundledServerPath as NSString).appendingPathComponent("server.js")
+            if FileManager.default.fileExists(atPath: serverJsPath) {
+                print("[ServerManager] server.js found at: \(serverJsPath)")
+            } else {
+                print("[ServerManager] ERROR: server.js not found at: \(serverJsPath)")
+            }
         } else {
             // Fallback to development location
             let appPath = Bundle.main.bundlePath
@@ -64,6 +76,7 @@ class ServerManager: ObservableObject {
         // Check if server directory exists
         guard let validServerPath = serverPath else {
             print("[ServerManager] Server directory not found")
+            NSLog("[ServerManager] Server directory not found")
             return false
         }
         
@@ -77,6 +90,7 @@ class ServerManager: ObservableObject {
         if let bundledNodePath = Bundle.main.path(forResource: "node/node", ofType: nil) {
             nodePath = bundledNodePath
             print("[ServerManager] Using bundled Node.js at: \(bundledNodePath)")
+            NSLog("[ServerManager] Using bundled Node.js at: %@", bundledNodePath)
         } else {
             // Fallback to system Node.js (development)
             let systemNodePaths = [
@@ -126,14 +140,29 @@ class ServerManager: ObservableObject {
         
         outputPipe.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData
-            if let output = String(data: data, encoding: .utf8) {
-                print("[Server] \(output)", terminator: "")
+            if data.count > 0 {
+                if let output = String(data: data, encoding: .utf8) {
+                    print("[Server] \(output)", terminator: "")
+                }
             }
         }
         
+        // Monitor process termination
+        process.terminationHandler = { proc in
+            print("[ServerManager] Process terminated with status: \(proc.terminationStatus)")
+            print("[ServerManager] Termination reason: \(proc.terminationReason)")
+        }
+        
         do {
+            print("[ServerManager] About to run process with:")
+            print("[ServerManager]   Executable: \(node)")
+            print("[ServerManager]   Arguments: \(process.arguments ?? [])")
+            print("[ServerManager]   Directory: \(validServerPath)")
+            print("[ServerManager]   Environment CLAUDE_CONFIG_DIR: \(environment["CLAUDE_CONFIG_DIR"] ?? "not set")")
+            
             try process.run()
             serverProcess = process
+            print("[ServerManager] Process started with PID: \(process.processIdentifier)")
             
             // Wait for server to start with multiple retry attempts
             var retryCount = 0

--- a/Sources/ClaudeUsageMonitor/ServerManager.swift
+++ b/Sources/ClaudeUsageMonitor/ServerManager.swift
@@ -114,6 +114,8 @@ class ServerManager: ObservableObject {
         if let claudePath = claudePath {
             environment["CLAUDE_CONFIG_DIR"] = claudePath
             print("[ServerManager] Setting CLAUDE_CONFIG_DIR to: \(claudePath)")
+        } else {
+            print("[ServerManager] WARNING: No claudePath set, server may not find data")
         }
         
         process.environment = environment

--- a/Sources/ClaudeUsageMonitor/ServerManager.swift
+++ b/Sources/ClaudeUsageMonitor/ServerManager.swift
@@ -8,21 +8,20 @@ class ServerManager: ObservableObject {
     private let serverPort = 3456
     @Published var isServerRunning = false
     var claudePath: String?
+    private var serverMonitorTask: Task<Void, Never>?
     
     private init() {}
     
-    func checkAndStartServer() {
+    func checkAndStartServer() async -> Bool {
         // Check if server is already running
-        Task {
-            if await isServerResponding() {
-                print("[ServerManager] Server already running")
-                isServerRunning = true
-                return
-            }
-            
-            // Try to start the server
-            startServer()
+        if await isServerResponding() {
+            print("[ServerManager] Server already running")
+            isServerRunning = true
+            return true
         }
+        
+        // Try to start the server
+        return await startServer()
     }
     
     private func isServerResponding() async -> Bool {
@@ -43,7 +42,7 @@ class ServerManager: ObservableObject {
         return false
     }
     
-    private func startServer() {
+    private func startServer() async -> Bool {
         print("[ServerManager] Attempting to start server")
         
         // First, try to find server in the app bundle (production)
@@ -65,7 +64,7 @@ class ServerManager: ObservableObject {
         // Check if server directory exists
         guard let validServerPath = serverPath else {
             print("[ServerManager] Server directory not found")
-            return
+            return false
         }
         
         // Create process to start server
@@ -98,12 +97,12 @@ class ServerManager: ObservableObject {
         
         guard let node = nodePath else {
             print("[ServerManager] Node.js not found")
-            return
+            return false
         }
         
         process.executableURL = URL(fileURLWithPath: node)
         // Add --max-old-space-size to prevent memory issues in sandboxed environment
-        process.arguments = ["--max-old-space-size=128", "server.js"]
+        process.arguments = ["--max-old-space-size=\(Constants.Server.nodeMemoryLimit)", "server.js"]
         process.currentDirectoryURL = URL(fileURLWithPath: validServerPath)
         
         // Set up environment
@@ -136,25 +135,74 @@ class ServerManager: ObservableObject {
             try process.run()
             serverProcess = process
             
-            // Wait a bit for server to start
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                Task {
-                    if await self.isServerResponding() {
-                        print("[ServerManager] Server started successfully")
-                        self.isServerRunning = true
-                    } else {
-                        print("[ServerManager] Server failed to start")
-                    }
+            // Wait for server to start with multiple retry attempts
+            var retryCount = 0
+            let maxRetries = Constants.Server.serverStartupRetryCount
+            let retryDelay = UInt64(Constants.Timing.serverStartupRetryDelay * 1_000_000_000)
+            
+            while retryCount < maxRetries {
+                try? await Task.sleep(nanoseconds: retryDelay)
+                
+                if await isServerResponding() {
+                    print("[ServerManager] Server started successfully after \(retryCount + 1) attempt(s)")
+                    isServerRunning = true
+                    startServerMonitoring()
+                    return true
                 }
+                
+                retryCount += 1
+                print("[ServerManager] Server not responding yet, retry \(retryCount)/\(maxRetries)")
             }
+            
+            print("[ServerManager] Server failed to start after \(maxRetries) attempts")
+            stopServer() // Clean up the process
+            return false
+            
         } catch {
             print("[ServerManager] Failed to start server: \(error)")
+            return false
         }
     }
     
     func stopServer() {
+        serverMonitorTask?.cancel()
+        serverMonitorTask = nil
         serverProcess?.terminate()
         serverProcess = nil
         isServerRunning = false
+    }
+    
+    private func startServerMonitoring() {
+        serverMonitorTask?.cancel()
+        
+        serverMonitorTask = Task {
+            print("[ServerManager] Starting server health monitoring")
+            
+            while !Task.isCancelled {
+                // Check at configured interval
+                let checkInterval = UInt64(Constants.Timing.serverHealthCheckInterval * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: checkInterval)
+                
+                if Task.isCancelled { break }
+                
+                // Check if server is still responding
+                let isResponding = await isServerResponding()
+                if !isResponding {
+                    print("[ServerManager] Server is not responding, attempting restart...")
+                    isServerRunning = false
+                    
+                    // Try to restart the server
+                    let restarted = await startServer()
+                    if restarted {
+                        print("[ServerManager] Server restarted successfully")
+                    } else {
+                        print("[ServerManager] Failed to restart server")
+                        // Could emit a notification here in the future
+                    }
+                }
+            }
+            
+            print("[ServerManager] Server monitoring stopped")
+        }
     }
 }

--- a/Sources/ClaudeUsageMonitor/SessionModels.swift
+++ b/Sources/ClaudeUsageMonitor/SessionModels.swift
@@ -5,6 +5,50 @@ struct BlocksResponse: Codable {
     let blocks: [SessionBlock]
 }
 
+// Response structure for session endpoint
+struct SessionResponse: Codable {
+    let sessions: [SessionData]
+    let totals: SessionTotals
+}
+
+struct SessionData: Codable {
+    let sessionId: String
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheCreationTokens: Int
+    let cacheReadTokens: Int
+    let totalTokens: Int
+    let totalCost: Double
+    let lastActivity: String
+    let modelsUsed: [String]
+    let modelBreakdowns: [ModelBreakdown]
+}
+
+struct SessionTotals: Codable {
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheCreationTokens: Int
+    let cacheReadTokens: Int
+    let totalTokens: Int
+    let totalCost: Double
+}
+
+struct ModelBreakdown: Codable {
+    let modelName: String
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheCreationTokens: Int
+    let cacheReadTokens: Int
+    let totalTokens: Int?
+    let totalCost: Double?
+    let cost: Double?
+    
+    // Provide cost accessor for compatibility
+    var actualCost: Double {
+        return cost ?? totalCost ?? 0.0
+    }
+}
+
 struct SessionBlock: Codable {
     let id: String
     let startTime: String

--- a/Sources/ClaudeUsageMonitor/SettingsTabView.swift
+++ b/Sources/ClaudeUsageMonitor/SettingsTabView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsTabView: View {
     @EnvironmentObject var monitor: UsageMonitor
+    @EnvironmentObject var dataAccessManager: ClaudeDataAccessManager
     @StateObject private var languageSettings = LanguageSettings.shared
     // @State private var notificationEnabled = Bundle.main.bundleIdentifier != nil ? NotificationManager.shared.isNotificationEnabled : false
     
@@ -116,6 +117,35 @@ struct SettingsTabView: View {
                 }
             }
             */
+            
+            Divider()
+            
+            // Data Access section
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Data Access")
+                    .font(.system(size: 16, weight: .semibold))
+                
+                HStack {
+                    Button(action: {
+                        dataAccessManager.resetAccess()
+                    }) {
+                        HStack {
+                            Image(systemName: "arrow.counterclockwise")
+                                .font(.system(size: 14))
+                            Text("Reset Data Access")
+                                .font(.system(size: 14))
+                        }
+                        .foregroundStyle(.orange)
+                    }
+                    .buttonStyle(.plain)
+                    
+                    Spacer()
+                }
+                
+                Text("Reset access permissions if you're having issues with data loading.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
             
             Spacer()
         }

--- a/Sources/ClaudeUsageMonitor/Utilities.swift
+++ b/Sources/ClaudeUsageMonitor/Utilities.swift
@@ -206,6 +206,15 @@ struct Constants {
         static let refreshInterval: TimeInterval = 300 // 5分
         static let animationDuration: Double = 0.3
         static let longAnimationDuration: Double = 0.5
+        static let serverRestartDelay: TimeInterval = 2.0
+        static let serverHealthCheckInterval: TimeInterval = 30.0
+        static let serverStartupRetryDelay: TimeInterval = 1.0
+        static let dataAccessWaitTime: TimeInterval = 2.0
+    }
+    
+    struct Server {
+        static let serverStartupRetryCount = 5
+        static let nodeMemoryLimit = 128 // MB
     }
     
     struct UI {

--- a/node.entitlements
+++ b/node.entitlements
@@ -6,5 +6,11 @@
     <true/>
     <key>com.apple.security.inherit</key>
     <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
 </dict>
 </plist>

--- a/node.entitlements
+++ b/node.entitlements
@@ -10,5 +10,11 @@
     <true/>
     <key>com.apple.security.files.user-selected.read-only</key>
     <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
 </dict>
 </plist>

--- a/node.entitlements
+++ b/node.entitlements
@@ -10,10 +10,5 @@
     <true/>
     <key>com.apple.security.files.user-selected.read-only</key>
     <true/>
-    <key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
-    <array>
-        <string>/.claude/</string>
-        <string>/.config/claude/</string>
-    </array>
 </dict>
 </plist>

--- a/node.entitlements
+++ b/node.entitlements
@@ -6,11 +6,13 @@
     <true/>
     <key>com.apple.security.inherit</key>
     <true/>
-    <key>com.apple.security.cs.allow-jit</key>
-    <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <key>com.apple.security.files.user-selected.read-only</key>
     <true/>
+    <key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+    <array>
+        <string>/.config/claude.ai/</string>
+    </array>
 </dict>
 </plist>

--- a/node.entitlements
+++ b/node.entitlements
@@ -12,7 +12,8 @@
     <true/>
     <key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
     <array>
-        <string>/.config/claude.ai/</string>
+        <string>/.claude/</string>
+        <string>/.config/claude/</string>
     </array>
 </dict>
 </plist>

--- a/scripts/create-app-bundle.sh
+++ b/scripts/create-app-bundle.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
 # Create macOS app bundle from Swift executable
-# Usage: ./scripts/create-app-bundle.sh <version>
+# Usage: ./scripts/create-app-bundle.sh [version] [--skip-signing]
 
 set -euo pipefail
 
 VERSION="${1:-0.0.0-dev}"
+SKIP_SIGNING=false
+
+# Parse arguments
+for arg in "$@"; do
+    case $arg in
+        --skip-signing)
+            SKIP_SIGNING=true
+            ;;
+    esac
+done
 
 echo "🔨 Creating macOS app bundle for version $VERSION"
 
@@ -132,8 +142,8 @@ echo ""
 echo "  Executable info:"
 file "$APP_PATH/Contents/MacOS/ClaudeCodeMonitor"
 
-# Sign Node.js binary if Developer ID is available
-if [ -f "$APP_PATH/Contents/Resources/node/node" ]; then
+# Sign Node.js binary if Developer ID is available and not skipping
+if [ -f "$APP_PATH/Contents/Resources/node/node" ] && [ "$SKIP_SIGNING" = false ]; then
     echo ""
     echo "Signing Node.js binary..."
     

--- a/scripts/test-local-with-node.sh
+++ b/scripts/test-local-with-node.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -e
+
+echo "🧪 Local testing script for ClaudeCodeMonitor with Node.js"
+echo ""
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Configuration
+NODE_VERSION="v20.18.2"
+NODE_VERSION_SHORT="20.18.2"
+APP_NAME="ClaudeCodeMonitor.app"
+
+# Step 1: Check if Node.js binaries exist
+echo "📦 Checking for Node.js binaries..."
+if [ ! -f "Resources/node/node" ]; then
+    echo -e "${YELLOW}Node.js binary not found. Downloading...${NC}"
+    
+    # Create directory
+    mkdir -p Resources/node
+    cd Resources/node
+    
+    # Download for both architectures
+    echo "  Downloading Node.js ${NODE_VERSION} for arm64..."
+    curl -L "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-darwin-arm64.tar.gz" -o node-arm64.tar.gz
+    tar -xzf node-arm64.tar.gz
+    mv node-${NODE_VERSION}-darwin-arm64/bin/node node-arm64
+    
+    echo "  Downloading Node.js ${NODE_VERSION} for x64..."
+    curl -L "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-darwin-x64.tar.gz" -o node-x64.tar.gz
+    tar -xzf node-x64.tar.gz
+    mv node-${NODE_VERSION}-darwin-x64/bin/node node-x64
+    
+    # Create universal binary
+    echo "  Creating universal binary..."
+    lipo -create -output node node-arm64 node-x64
+    chmod +x node
+    
+    # Cleanup
+    rm -rf node-*.tar.gz node-${NODE_VERSION}-darwin-* node-arm64 node-x64
+    
+    cd ../..
+    echo -e "${GREEN}✅ Node.js binary created${NC}"
+else
+    echo -e "${GREEN}✅ Node.js binary already exists${NC}"
+fi
+
+# Step 2: Build the app
+echo ""
+echo "🔨 Building app bundle (skipping signing)..."
+./scripts/create-app-bundle.sh 0.0.0-dev --skip-signing
+
+# Step 3: Sign Node.js with entitlements
+echo ""
+echo "🔏 Signing Node.js binary with entitlements (ad-hoc)..."
+if [ -f "${APP_NAME}/Contents/Resources/node/node" ]; then
+    # Remove existing signature first
+    codesign --remove-signature "${APP_NAME}/Contents/Resources/node/node" 2>/dev/null || true
+    # Sign with ad-hoc signature
+    codesign --force --sign - --entitlements node.entitlements "${APP_NAME}/Contents/Resources/node/node"
+    echo -e "${GREEN}✅ Node.js binary signed${NC}"
+else
+    echo -e "${RED}❌ Node.js binary not found in app bundle${NC}"
+    exit 1
+fi
+
+# Step 4: Sign the app
+echo ""
+echo "🔏 Signing app with entitlements (ad-hoc)..."
+# Remove existing signature first
+codesign --remove-signature "${APP_NAME}" 2>/dev/null || true
+# Sign with ad-hoc signature
+codesign --deep --force --sign - --entitlements ClaudeCodeMonitor.entitlements "${APP_NAME}"
+echo -e "${GREEN}✅ App signed${NC}"
+
+# Step 5: Verify signatures
+echo ""
+echo "🔍 Verifying signatures..."
+codesign --verify --verbose "${APP_NAME}/Contents/Resources/node/node"
+codesign --verify --verbose "${APP_NAME}"
+
+# Step 6: Check entitlements
+echo ""
+echo "📋 Node.js entitlements:"
+codesign -d --entitlements - "${APP_NAME}/Contents/Resources/node/node" 2>&1 | grep -A 20 "<?xml"
+
+echo ""
+echo "📋 App entitlements:"
+codesign -d --entitlements - "${APP_NAME}" 2>&1 | grep -A 20 "<?xml"
+
+# Step 7: Launch the app
+echo ""
+echo -e "${GREEN}🚀 Ready to test!${NC}"
+echo ""
+echo "Launch the app with:"
+echo "  open ${APP_NAME}"
+echo ""
+echo "Monitor logs with:"
+echo "  log stream --predicate 'processImagePath CONTAINS \"ClaudeCodeMonitor\"'"
+echo ""
+echo "Check server logs:"
+echo "  tail -f ~/Library/Logs/ClaudeCodeMonitor/server.log"

--- a/scripts/test-local-with-node.sh
+++ b/scripts/test-local-with-node.sh
@@ -57,13 +57,19 @@ echo "🔨 Building app bundle (skipping signing)..."
 
 # Step 3: Sign Node.js with entitlements
 echo ""
-echo "🔏 Signing Node.js binary with entitlements (ad-hoc)..."
+echo "🔏 Checking Node.js binary signature..."
 if [ -f "${APP_NAME}/Contents/Resources/node/node" ]; then
-    # Remove existing signature first
-    codesign --remove-signature "${APP_NAME}/Contents/Resources/node/node" 2>/dev/null || true
-    # Sign with ad-hoc signature
-    codesign --force --sign - --entitlements node.entitlements "${APP_NAME}/Contents/Resources/node/node"
-    echo -e "${GREEN}✅ Node.js binary signed${NC}"
+    # Check if Node.js has valid Developer ID signature
+    if codesign -dvv "${APP_NAME}/Contents/Resources/node/node" 2>&1 | grep -q "Developer ID Application: Node.js Foundation"; then
+        echo -e "${GREEN}✅ Node.js has valid Developer ID signature, keeping it${NC}"
+    else
+        echo "⚠️  Node.js doesn't have Developer ID signature, signing with ad-hoc..."
+        # Remove existing signature first
+        codesign --remove-signature "${APP_NAME}/Contents/Resources/node/node" 2>/dev/null || true
+        # Sign with ad-hoc signature
+        codesign --force --sign - --entitlements node.entitlements "${APP_NAME}/Contents/Resources/node/node"
+        echo -e "${GREEN}✅ Node.js binary signed with ad-hoc${NC}"
+    fi
 else
     echo -e "${RED}❌ Node.js binary not found in app bundle${NC}"
     exit 1
@@ -74,8 +80,8 @@ echo ""
 echo "🔏 Signing app with entitlements (ad-hoc)..."
 # Remove existing signature first
 codesign --remove-signature "${APP_NAME}" 2>/dev/null || true
-# Sign with ad-hoc signature
-codesign --deep --force --sign - --entitlements ClaudeCodeMonitor.entitlements "${APP_NAME}"
+# Sign with ad-hoc signature (without --deep to preserve inner signatures)
+codesign --force --sign - --entitlements ClaudeCodeMonitor.entitlements "${APP_NAME}"
 echo -e "${GREEN}✅ App signed${NC}"
 
 # Step 5: Verify signatures

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,7 +8,7 @@
       "name": "claude-usage-server",
       "version": "1.0.0",
       "dependencies": {
-        "ccusage": "^0.8.0",
+        "ccusage": "^15.2.0",
         "express": "^4.18.2"
       }
     },
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/ccusage": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/ccusage/-/ccusage-0.8.0.tgz",
-      "integrity": "sha512-m/BrmMExMX/KwfnShN35VR7g5ePolEIF5tF/AJ8dS8eNB2fNu2LQ7hGbn/qaDR4c8Xi66kwwJmxhm37X5sFYPA==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/ccusage/-/ccusage-15.2.0.tgz",
+      "integrity": "sha512-DpUI61fDTHYIjSjjU9flTkCRA44THyy0C0fIQi1f69HLn9U7b1rMSHBJdOQ3eNNWY0LMbn15CXWXmbAAEvCLbA==",
       "license": "MIT",
       "bin": {
         "ccusage": "dist/index.js"

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "ccusage": "^0.8.0",
+    "ccusage": "^15.2.0",
     "express": "^4.18.2"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "start": "node server-fixed.js"
+    "start": "node server.js"
   },
   "dependencies": {
     "ccusage": "^0.8.0",

--- a/server/server.js
+++ b/server/server.js
@@ -76,10 +76,11 @@ app.get('/usage', async (req, res) => {
   }
 });
 
-// Get active session block data
+// Get active block data (5-hour sessions)
 app.get('/blocks/active', async (req, res) => {
   try {
-    const npx = spawn('npx', ['ccusage', 'blocks', '--active', '--json']);
+    const env = process.env.CLAUDE_CONFIG_DIR ? { ...process.env } : process.env;
+    const npx = spawn('npx', ['ccusage', 'blocks', '--active', '--json'], { env });
     let output = '';
     let error = '';
 
@@ -102,6 +103,40 @@ app.get('/blocks/active', async (req, res) => {
         res.json(data);
       } catch (parseError) {
         res.status(500).json({ error: 'Failed to parse blocks data' });
+      }
+    });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Get session data (conversation sessions)
+app.get('/session', async (req, res) => {
+  try {
+    const env = process.env.CLAUDE_CONFIG_DIR ? { ...process.env } : process.env;
+    const npx = spawn('npx', ['ccusage', 'session', '--json'], { env });
+    let output = '';
+    let error = '';
+
+    npx.stdout.on('data', (data) => {
+      output += data.toString();
+    });
+
+    npx.stderr.on('data', (data) => {
+      error += data.toString();
+    });
+
+    npx.on('close', (code) => {
+      if (code !== 0) {
+        res.status(500).json({ error: error || 'Failed to get session data' });
+        return;
+      }
+
+      try {
+        const data = JSON.parse(output);
+        res.json(data);
+      } catch (parseError) {
+        res.status(500).json({ error: 'Failed to parse session data' });
       }
     });
   } catch (error) {


### PR DESCRIPTION
## 問題と背景

v0.1.10〜v0.1.12でDMGインストールしたアプリが正常に起動しない問題が発生していました。

### 主な課題
1. **Node.js実行エラー**: App Sandbox環境でバンドルしたNode.jsがJITメモリエラーで起動できない
2. **データアクセス問題**: ccusageが`~/.claude`ディレクトリにアクセスできない
3. **UX問題**: データフォルダへのアクセス許可フローが複雑

## 解決方法

### 1. Node.jsエンタイトルメント設定
App Sandboxを維持しながらNode.jsを実行するための最小限のエンタイトルメント：

```xml
<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
<true/>
```

メモリ制限も追加して安定性を向上：
```bash
node --max-old-space-size=128 server.js
```

### 2. フォルダアクセス許可システム

#### 初回起動時のフロー
1. アプリ起動時に`~/.claude`へのアクセスをチェック
2. アクセスがない場合、DataAccessViewを表示
3. 「アクセスを許可」ボタンでNSOpenPanelを表示
4. `~/.claude`フォルダが自動的に選択された状態で表示
5. ユーザーが「Grant Access」をクリック
6. パスを保存し、サーバーにCLAUDE_CONFIG_DIR環境変数として渡す

#### 技術的な詳細
- App Sandboxでは通常のファイルアクセスが制限される
- NSOpenPanelで選択されたフォルダは一時的にアクセス可能
- セキュリティスコープ付きブックマークは不要（通常のパス保存で十分）
- サーバープロセスは環境変数経由でパスを受け取る

### 3. UI/UXの改善

#### ポップオーバーの挙動
- NSOpenPanel表示時にEventMonitorを一時停止
- ダイアログ表示中もポップオーバーが閉じない
- ダイアログ終了後にEventMonitorを再開

#### 設定タブの機能追加
- 「Data Access」セクションを追加
- 「Reset Data Access」ボタンで再設定可能
- デバッグビルドに限定せず、全ユーザーが利用可能

### 4. ccusageとセッションデータ

#### ccusageのアップデート
- 0.8.0 → 15.2.0へ更新
- `blocks --active`コマンドで5時間セッションデータを取得
- リアルタイムのトークン使用量、バーンレート、残り時間を表示

## テスト手順

1. DMGをビルド: `./scripts/build-release.sh`
2. DMGをマウントしてアプリをApplicationsフォルダにコピー
3. アプリを起動
4. 初回起動時にフォルダアクセス許可ダイアログが表示されることを確認
5. 許可後、使用状況データが正しく表示されることを確認
6. 設定タブでリセット機能が動作することを確認

## 今後の課題

- Node.jsバイナリの実行権限問題（現在は手動でサーバー起動が必要）
- Developer ID署名でのノータリゼーション対応
- Homebrew Caskでの配布準備