### PR TITLE
Fix: Use ad-hoc signing for Node.js binary in app bundle

### DIFF
--- a/scripts/create-app-bundle.sh
+++ b/scripts/create-app-bundle.sh
@@ -147,31 +147,8 @@ if [ -f "$APP_PATH/Contents/Resources/node/node" ] && [ "$SKIP_SIGNING" = false 
     echo ""
     echo "Signing Node.js binary..."
     
-    # Check if we have a Developer ID
-    if security find-identity -v -p codesigning | grep -q "Developer ID Application"; then
-        # Get the first Developer ID
-        DEVELOPER_ID=$(security find-identity -v -p codesigning | grep "Developer ID Application" | head -1 | awk -F'"' '{print $2}')
-        echo "  Using Developer ID: $DEVELOPER_ID"
-        
-        # Sign with node entitlements
-        if [ -f "node.entitlements" ]; then
-            codesign --force --sign "$DEVELOPER_ID" \
-                --entitlements node.entitlements \
-                --options runtime \
-                --timestamp \
-                "$APP_PATH/Contents/Resources/node/node"
-            echo "  ✅ Node.js binary signed"
-        else
-            echo "  ⚠️  node.entitlements not found, signing without entitlements"
-            codesign --force --sign "$DEVELOPER_ID" \
-                --options runtime \
-                --timestamp \
-                "$APP_PATH/Contents/Resources/node/node"
-        fi
-    else
-        echo "  ⚠️  No Developer ID found, using ad-hoc signing"
-        codesign --force --sign - "$APP_PATH/Contents/Resources/node/node"
-    fi
+    codesign --force --sign - "$APP_PATH/Contents/Resources/node/node"
+    echo "  ✅ Node.js binary signed"
 fi
 
 echo ""


### PR DESCRIPTION
最新バージョンのDMGが起動に失敗する問題の原因を調査しました。
Node.jsバイナリのコード署名時に  エラーが発生しており、これが起動失敗の原因と考えられます。

このPRでは、🔨 Creating macOS app bundle for version 0.0.0-dev
Building universal binary...
  Building for arm64...
[0/1] Planning build
Building for production...
[0/2] Write swift-version-2F0A5646E1D333AE.txt
Build complete! (0.13s)
  Building for x86_64...
[0/1] Planning build
Building for production...
[0/2] Write swift-version-2F0A5646E1D333AE.txt
Build complete! (0.13s)
  Found ARM64 binary: .build/arm64-apple-macosx/release/ClaudeCodeMonitor
  Found X86_64 binary: .build/x86_64-apple-macosx/release/ClaudeCodeMonitor
  Creating universal binary...
✅ Universal binary created
.build/universal/release/ClaudeCodeMonitor: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
.build/universal/release/ClaudeCodeMonitor (for architecture x86_64):	Mach-O 64-bit executable x86_64
.build/universal/release/ClaudeCodeMonitor (for architecture arm64):	Mach-O 64-bit executable arm64
Architectures in the fat file: .build/universal/release/ClaudeCodeMonitor are: x86_64 arm64 

Creating app bundle...
  Removing existing app bundle...
  Copying executable...
  Copying Info.plist...
  Updating version to 0.0.0-dev...
  Looking for resource bundles...
    Found bundle: ClaudeCodeMonitor_ClaudeCodeMonitor.bundle
  Copying Node.js binary...
    Node.js binary copied
  Copying server files...
    Installing server dependencies...
    Server files copied

Verifying app bundle structure...
  App bundle root:
total 0
drwxr-xr-x@  3 kotahayashi  staff    96  7  1 09:17 .
drwxr-xr-x@ 39 kotahayashi  staff  1248  7  1 09:17 ..
drwxr-xr-x@  5 kotahayashi  staff   160  7  1 09:17 Contents

  Contents directory:
total 8
drwxr-xr-x@ 5 kotahayashi  staff  160  7  1 09:17 .
drwxr-xr-x@ 3 kotahayashi  staff   96  7  1 09:17 ..
-rw-r--r--@ 1 kotahayashi  staff  845  7  1 09:17 Info.plist
drwxr-xr-x@ 3 kotahayashi  staff   96  7  1 09:17 MacOS
drwxr-xr-x@ 5 kotahayashi  staff  160  7  1 09:17 Resources

  MacOS directory:
total 4608
drwxr-xr-x@ 3 kotahayashi  staff       96  7  1 09:17 .
drwxr-xr-x@ 5 kotahayashi  staff      160  7  1 09:17 ..
-rwxr-xr-x@ 1 kotahayashi  staff  2357232  7  1 09:17 ClaudeCodeMonitor

  Resources directory:
total 0
drwxr-xr-x@ 5 kotahayashi  staff  160  7  1 09:17 .
drwxr-xr-x@ 5 kotahayashi  staff  160  7  1 09:17 ..
drwxr-xr-x@ 5 kotahayashi  staff  160  7  1 09:17 ClaudeCodeMonitor_ClaudeCodeMonitor.bundle
drwxr-xr-x@ 3 kotahayashi  staff   96  7  1 09:17 node
drwxr-xr-x@ 8 kotahayashi  staff  256  7  1 09:17 server

  Executable info:
ClaudeCodeMonitor.app/Contents/MacOS/ClaudeCodeMonitor: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
ClaudeCodeMonitor.app/Contents/MacOS/ClaudeCodeMonitor (for architecture x86_64):	Mach-O 64-bit executable x86_64
ClaudeCodeMonitor.app/Contents/MacOS/ClaudeCodeMonitor (for architecture arm64):	Mach-O 64-bit executable arm64

Signing Node.js binary...
  ✅ Node.js binary signed

✅ App bundle created successfully: ClaudeCodeMonitor.app
   Version: 0.0.0-dev スクリプト内のNode.jsバイナリの署名方法を、Developer ID を使用した署名から ad-hoc signing () に変更しました。

これにより、Node.jsバイナリの署名エラーが解消され、アプリの起動問題が解決される可能性があります。