### PR TITLE
fix: Settingsタブから不要なData Accessセクションを削除

### DIFF
--- a/Sources/ClaudeUsageMonitor/SettingsTabView.swift
+++ b/Sources/ClaudeUsageMonitor/SettingsTabView.swift
@@ -121,35 +121,6 @@ struct SettingsTabView: View {
             }
             */
 
-            Divider()
-
-            // Data Access section
-            VStack(alignment: .leading, spacing: 12) {
-                Text("Data Access")
-                    .font(.system(size: 16, weight: .semibold))
-
-                HStack {
-                    Button(action: {
-                        dataAccessManager.resetAccess()
-                    }) {
-                        HStack {
-                            Image(systemName: "arrow.counterclockwise")
-                                .font(.system(size: 14))
-                            Text("Reset Data Access")
-                                .font(.system(size: 14))
-                        }
-                        .foregroundStyle(.orange)
-                    }
-                    .buttonStyle(.plain)
-
-                    Spacer()
-                }
-
-                Text("Reset access permissions if you're having issues with data loading.")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-            }
-
             Spacer()
         }
     }


### PR DESCRIPTION
## Summary
- Settingsタブから不要な「Data Access」セクションを削除しました
- 修正前の名残として残っていたUIコンポーネントの削除

## 変更理由
現在の実装では、`ClaudeDataAccessManager`が初回起動時に自動的にアクセス権限を処理するため、手動でリセットするボタンは不要です。

## 変更内容
- `SettingsTabView.swift`から以下を削除:
  - Data Accessセクションのタイトル
  - Reset Data Accessボタン
  - 説明テキスト
  - 関連するDivider

## 影響範囲
- UIの変更のみで、アプリのデータアクセス機能には影響しません
- `ClaudeDataAccessManager`自体は引き続き`ContentView`で使用されます

## テスト
- [x] アプリをビルドしてエラーがないことを確認
- [x] Settingsタブを開いてData Accessセクションが削除されていることを確認
- [x] 他のタブの動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)