### PR TITLE
fix: タイムゾーン処理を修正し、月次データを正しく計算

### DIFF
--- a/Sources/ClaudeUsageMonitor/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/ContentView.swift
@@ -333,7 +333,7 @@ struct CurrentSessionView: View {
                             Capsule()
                                 .fill(Color.blue.opacity(0.15))
                         )
-                    Text(L10n.Session.resetTime(time: formatTime(session.endTime)))
+                    Text(L10n.Session.resetTime(time: formatSessionEndTime(session.endTime)))
                         .font(.system(size: 10))
                         .foregroundStyle(.secondary)
                 }
@@ -353,6 +353,10 @@ struct CurrentSessionView: View {
 
     private func formatTime(_ timeString: String) -> String {
         return Date.formatTime(from: timeString)
+    }
+    
+    private func formatSessionEndTime(_ timeString: String) -> String {
+        return Date.formatUserFriendlyDateTime(from: timeString)
     }
 
     private func getElapsedTime(from startTimeString: String) -> String {

--- a/Sources/ClaudeUsageMonitor/Localization.swift
+++ b/Sources/ClaudeUsageMonitor/Localization.swift
@@ -206,6 +206,8 @@ struct L10n {
         static func minutes(minutes: Int) -> String {
             return "time.minutes".localized(with: minutes)
         }
+        static var today: String { "time.today".localized }
+        static var tomorrow: String { "time.tomorrow".localized }
     }
 
     struct Status {

--- a/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
@@ -38,7 +38,7 @@
 "history.sessionDetails" = "Session: %@ tokens, from %@ to %@";
 "history.noHistory" = "No history available";
 "history.tokensFormat" = "%@ tokens";
-"history.referenceNote" = "※Daily and monthly cost information is for reference only.\nClaude Code resets token limits every 5-hour session.";
+"history.referenceNote" = "※Daily and monthly cost information is for reference only.\nClaude Code resets token limits every 5-hour session.\nDate calculations use your system's local timezone.";
 "history.time" = "Time";
 "history.tokens" = "Tokens";
 "history.noData" = "No data available";

--- a/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
@@ -72,6 +72,8 @@
 // Time format
 "time.hoursMinutes" = "%d hours %d minutes";
 "time.minutes" = "%d minutes";
+"time.today" = "Today";
+"time.tomorrow" = "Tomorrow";
 
 // Settings
 "settings.planSelection" = "Select Plan";

--- a/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
@@ -72,6 +72,8 @@
 // Time format
 "time.hoursMinutes" = "%d時間%d分";
 "time.minutes" = "%d分";
+"time.today" = "今日";
+"time.tomorrow" = "明日";
 
 // Settings
 "settings.planSelection" = "プラン選択";

--- a/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
@@ -38,7 +38,7 @@
 "history.sessionDetails" = "セッション: %@トークン、%@ 〜 %@";
 "history.noHistory" = "履歴がありません";
 "history.tokensFormat" = "%@ トークン";
-"history.referenceNote" = "※日次・月次のコスト情報は参考値です。\nClaude Codeは5時間セッションごとにトークン制限がリセットされます。";
+"history.referenceNote" = "※日次・月次のコスト情報は参考値です。\nClaude Codeは5時間セッションごとにトークン制限がリセットされます。\n日付の計算はシステムのローカルタイムゾーンを使用します。";
 "history.time" = "時間";
 "history.tokens" = "トークン";
 "history.noData" = "データがありません";

--- a/Sources/ClaudeUsageMonitor/Utilities.swift
+++ b/Sources/ClaudeUsageMonitor/Utilities.swift
@@ -41,6 +41,71 @@ extension Date {
         formatter.timeZone = TimeZone.current
         return formatter.string(from: self)
     }
+    
+    /// ユーザーフレンドリーな日時表示（今日、明日、曜日など）
+    static func formatUserFriendlyDateTime(from isoString: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        
+        // Try multiple formats
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var date = formatter.date(from: isoString)
+        
+        if date == nil {
+            formatter.formatOptions = [.withInternetDateTime]
+            date = formatter.date(from: isoString)
+        }
+        
+        if date == nil {
+            // Try with basic format
+            formatter.formatOptions = [.withFullDate, .withFullTime, .withTimeZone, .withColonSeparatorInTimeZone]
+            date = formatter.date(from: isoString)
+        }
+        
+        guard let date = date else {
+            print("Failed to parse date: \(isoString)")
+            return formatTime(from: isoString, format: "MM/dd HH:mm")
+        }
+        
+        let displayFormatter = DateFormatter()
+        displayFormatter.timeZone = TimeZone.current
+        displayFormatter.locale = Locale.current
+        
+        let calendar = Calendar.current
+        let now = Date()
+        
+        if calendar.isDateInToday(date) {
+            // Use localized "Today"
+            displayFormatter.doesRelativeDateFormatting = true
+            displayFormatter.dateStyle = .short
+            displayFormatter.timeStyle = .short
+            let result = displayFormatter.string(from: date)
+            // Extract time part and prepend "Today"
+            if let timeRange = result.range(of: " ") {
+                let timePart = String(result[timeRange.upperBound...])
+                return "\(L10n.Time.today) \(timePart)"
+            }
+            return result
+        } else if calendar.isDateInTomorrow(date) {
+            // Use localized "Tomorrow"
+            displayFormatter.dateFormat = "HH:mm"
+            let time = displayFormatter.string(from: date)
+            return "\(L10n.Time.tomorrow) \(time)"
+        } else {
+            // Check if within next 7 days
+            let daysDiff = calendar.dateComponents([.day], from: now, to: date).day ?? 0
+            
+            if daysDiff > 0 && daysDiff <= 7 {
+                // Show weekday name
+                displayFormatter.dateFormat = "E HH:mm"
+            } else {
+                // Show date
+                displayFormatter.dateFormat = "MM/dd HH:mm"
+            }
+            
+            return displayFormatter.string(from: date)
+        }
+    }
 }
 
 // MARK: - Color Extensions

--- a/server/server-optimized.js
+++ b/server/server-optimized.js
@@ -25,7 +25,12 @@ app.get('/usage', async (req, res) => {
       return;
     }
 
-    const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    // Use local timezone for date calculation to match ccusage behavior
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const today = `${year}${month}${day}`;
     
     // Get today's usage data
     const todayData = await loadDailyUsageData({

--- a/server/server.js
+++ b/server/server.js
@@ -8,17 +8,26 @@ const PORT = 3456;
 
 app.get('/usage', async (req, res) => {
   try {
-    const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    // Use local timezone for date calculation to match ccusage behavior
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const today = `${year}${month}${day}`;
     
     // Get today's usage data
     const todayData = await loadDailyUsageData({
       since: today,
+      until: today,
     });
     
-    // Get current month's data
+    // Get current month's data with explicit date range
     const currentMonth = today.slice(0, 6);
+    const lastDayOfMonth = new Date(year, now.getMonth() + 1, 0).getDate();
+    const monthEnd = `${currentMonth}${String(lastDayOfMonth).padStart(2, '0')}`;
     const monthData = await loadDailyUsageData({
       since: currentMonth + '01',
+      until: monthEnd,
     });
     
     // Calculate today's totals


### PR DESCRIPTION
## 概要
月次データの計算でタイムゾーンが正しく考慮されていない問題を修正しました。

## 問題
- サーバー側でUTC時刻（`toISOString()`）を使用していたため、日本時間の0:00〜8:59の間に前日・前月のデータとして扱われていた
- 「This Month」の表示が月初で正しく更新されない

## 修正内容
1. **サーバー側のタイムゾーン処理**
   - `new Date().toISOString()`の使用をやめ、ローカルタイムゾーンで日付を計算
   - 明示的な日付範囲指定（`until`パラメータ）により月末まで正確に含める

2. **ユーザーへの説明追加**
   - 英語・日本語のローカライゼーションファイルに「日付の計算はシステムのローカルタイムゾーンを使用します」という注釈を追加

## テスト
- [x] JST環境で月初（7月1日）のデータが正しく「今月」として表示される
- [x] サーバーAPIが正しくローカルタイムゾーンベースの月次データを返す
- [x] ccusageライブラリとの動作が一致する

🤖 Generated with [Claude Code](https://claude.ai/code)