### PR TITLE
feat: スクリーンショット共有機能を追加

### DIFF
--- a/Sources/ClaudeUsageMonitor/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/ContentView.swift
@@ -5,6 +5,8 @@ struct ContentView: View {
     @EnvironmentObject var dataAccessManager: ClaudeDataAccessManager
     @State private var selectedTab = 0
     @State private var isRefreshing = false
+    @State private var showCopiedFeedback = false
+    
     @Environment(\.colorScheme)
     var colorScheme
 
@@ -41,6 +43,22 @@ struct ContentView: View {
                         Spacer()
 
                         HStack(spacing: 8) {
+                            // Share button - only show on Current or History tabs
+                            if selectedTab == 0 || selectedTab == 1 {
+                                Button(action: {
+                                    shareScreenshot()
+                                }) {
+                                    Image(systemName: showCopiedFeedback ? "checkmark" : "square.and.arrow.up")
+                                        .font(.system(size: 13))
+                                        .foregroundStyle(showCopiedFeedback ? .green : .secondary)
+                                        .animation(.easeInOut(duration: 0.2), value: showCopiedFeedback)
+                                }
+                                .buttonStyle(PlainButtonStyle())
+                                .help("クリップボードにコピー")
+                                .keyboardShortcut("s", modifiers: .command)
+                                .accessibilityLabel("クリップボードにコピー")
+                            }
+                            
                             Button(action: {
                                 withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                                     isRefreshing = true
@@ -168,6 +186,53 @@ struct ContentView: View {
             }
         }
         .frame(width: 380, height: 480)
+    }
+    
+    private func shareScreenshot() {
+        Task { @MainActor in
+            // Create the content view to capture based on selected tab
+            let contentToCapture: AnyView
+            
+            switch selectedTab {
+            case 0:
+                // Current session tab content
+                if let session = monitor.usageData.activeSession {
+                    contentToCapture = AnyView(
+                        CurrentSessionView(session: session, monitor: monitor)
+                            .padding()
+                            .frame(width: 380)
+                            .background(Color(NSColor.windowBackgroundColor))
+                    )
+                } else {
+                    contentToCapture = AnyView(
+                        EmptyStateView(message: L10n.Session.noActiveSession)
+                            .padding()
+                            .frame(width: 380, height: 400)
+                            .background(Color(NSColor.windowBackgroundColor))
+                    )
+                }
+            case 1:
+                // History tab content
+                contentToCapture = AnyView(
+                    HistoryView(monitor: monitor)
+                        .padding()
+                        .frame(width: 380)
+                        .background(Color(NSColor.windowBackgroundColor))
+                )
+            default:
+                return
+            }
+            
+            let success = await ScreenshotManager.shared.captureViewContent(contentToCapture)
+            if success {
+                // Show visual feedback
+                showCopiedFeedback = true
+                
+                // Reset after delay
+                try? await Task.sleep(nanoseconds: 1_500_000_000) // 1.5 seconds
+                showCopiedFeedback = false
+            }
+        }
     }
 }
 

--- a/Sources/ClaudeUsageMonitor/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/ContentView.swift
@@ -42,7 +42,7 @@ struct ContentView: View {
 
                         Spacer()
 
-                        HStack(spacing: 8) {
+                        HStack(spacing: 12) {
                             // Share button - only show on Current or History tabs
                             if selectedTab == 0 || selectedTab == 1 {
                                 Button(action: {
@@ -357,7 +357,7 @@ struct CurrentSessionView: View {
                     Text(L10n.Session.burnRate)
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(.secondary)
-                    Text("\(monitor.usageData.sessionBurnRate)/分")
+                    Text("\(monitor.usageData.sessionBurnRate) \(L10n.Session.tokensPerMin)")
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundStyle(.orange)
                 }

--- a/Sources/ClaudeUsageMonitor/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/ContentView.swift
@@ -233,8 +233,10 @@ struct ContentView: View {
                 if let session = monitor.usageData.activeSession {
                     let tokens = monitor.formatTokens(session.totalTokens)
                     let cost = String(format: "%.2f", session.costUSD)
+                    let remainingTime = monitor.usageData.sessionRemainingTimeForShare
                     textContent = """
                     \(String(format: L10n.Share.CurrentSession.consuming, tokens, cost))
+                    \(String(format: L10n.Share.CurrentSession.resetIn, remainingTime))
                     
                     \(L10n.Share.hashtags)
                     """

--- a/Sources/ClaudeUsageMonitor/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/ContentView.swift
@@ -231,28 +231,28 @@ struct ContentView: View {
             switch selectedTab {
             case 0:
                 if let session = monitor.usageData.activeSession {
-                    let usage = monitor.usageData.sessionUsagePercentage
+                    let tokens = monitor.formatTokens(session.totalTokens)
+                    let cost = String(format: "%.2f", session.costUSD)
                     textContent = """
-                    Claude Code Monitor - Usage Report
+                    \(String(format: L10n.Share.CurrentSession.consuming, tokens, cost))
                     
-                    📊 Usage: \(String(format: "%.1f", usage))%
-                    💰 Cost: $\(String(format: "%.2f", session.costUSD))
-                    🔥 Burn Rate: \(monitor.usageData.sessionBurnRate) tokens/min
-                    ⏱️ Time Until Reset: \(monitor.usageData.sessionRemainingTime)
-                    
-                    #ClaudeCode #AIProductivity #DeveloperTools
+                    \(L10n.Share.hashtags)
                     """
                 } else {
-                    textContent = "Claude Code Monitor - No active session\n\n#ClaudeCode #AIProductivity"
+                    textContent = "\(L10n.Share.CurrentSession.noSession)\n\n\(L10n.Share.hashtags)"
                 }
             case 1:
-                let totalCost = monitor.usageData.monthlyTotal?.totalCost ?? 0.0
+                let todayTokens = monitor.formatTokens(monitor.usageData.todayUsage?.totalTokens ?? 0)
+                let todayCost = String(format: "%.2f", monitor.usageData.todayUsage?.totalCost ?? 0.0)
+                let monthTokens = monitor.formatTokens(monitor.usageData.monthlyTotal?.totalTokens ?? 0)
+                let monthCost = String(format: "%.2f", monitor.usageData.monthlyTotal?.totalCost ?? 0.0)
+                
                 textContent = """
-                Claude Code Monitor - History
+                \(L10n.Share.History.title)
+                \(String(format: L10n.Share.History.today, todayTokens, todayCost))
+                \(String(format: L10n.Share.History.month, monthTokens, monthCost))
                 
-                💸 Monthly Total Cost: $\(String(format: "%.2f", totalCost))
-                
-                #ClaudeCode #AIProductivity #DeveloperTools
+                \(L10n.Share.hashtags)
                 """
             default:
                 textContent = ""

--- a/Sources/ClaudeUsageMonitor/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/ContentView.swift
@@ -347,9 +347,17 @@ struct CurrentSessionView: View {
                 .accessibilityAddTraits(.updatesFrequently)
 
                 HStack {
-                    Text(L10n.Session.used(percentage: monitor.usageData.formattedSessionPercentage))
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(.secondary)
+                    HStack(spacing: 4) {
+                        Text(L10n.Session.used(percentage: monitor.usageData.formattedSessionPercentage))
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.secondary)
+                        Text("•")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                        Text(L10n.Session.tokensConsumed(tokens: monitor.formatTokens(session.totalTokens)))
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.secondary)
+                    }
                     Spacer()
                     if monitor.usageData.sessionUsagePercentage > 90 {
                         Label(L10n.Session.highUsageWarning, systemImage: "exclamationmark.triangle.fill")

--- a/Sources/ClaudeUsageMonitor/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/ContentView.swift
@@ -244,9 +244,9 @@ struct ContentView: View {
                     textContent = "\(L10n.Share.CurrentSession.noSession)\n\n\(L10n.Share.hashtags)"
                 }
             case 1:
-                let todayTokens = monitor.formatTokens(monitor.usageData.todayUsage?.totalTokens ?? 0)
+                let todayTokens = monitor.formatTokens(monitor.usageData.todayBillableTokens)
                 let todayCost = String(format: "%.2f", monitor.usageData.todayUsage?.totalCost ?? 0.0)
-                let monthTokens = monitor.formatTokens(monitor.usageData.monthlyTotal?.totalTokens ?? 0)
+                let monthTokens = monitor.formatTokens(monitor.usageData.monthlyBillableTokens)
                 let monthCost = String(format: "%.2f", monitor.usageData.monthlyTotal?.totalCost ?? 0.0)
                 
                 textContent = """

--- a/Sources/ClaudeUsageMonitor/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/ContentView.swift
@@ -201,14 +201,16 @@ struct ContentView: View {
                         CurrentSessionView(session: session, monitor: monitor)
                             .padding()
                             .frame(width: 380)
-                            .background(Color(NSColor.windowBackgroundColor))
+                            .background(colorScheme == .dark ? Color.black : Color.white)
+                            .environment(\.colorScheme, colorScheme)
                     )
                 } else {
                     contentToCapture = AnyView(
                         EmptyStateView(message: L10n.Session.noActiveSession)
                             .padding()
                             .frame(width: 380, height: 400)
-                            .background(Color(NSColor.windowBackgroundColor))
+                            .background(colorScheme == .dark ? Color.black : Color.white)
+                            .environment(\.colorScheme, colorScheme)
                     )
                 }
             case 1:
@@ -217,7 +219,8 @@ struct ContentView: View {
                     HistoryView(monitor: monitor)
                         .padding()
                         .frame(width: 380)
-                        .background(Color(NSColor.windowBackgroundColor))
+                        .background(colorScheme == .dark ? Color.black : Color.white)
+                        .environment(\.colorScheme, colorScheme)
                 )
             default:
                 return

--- a/Sources/ClaudeUsageMonitor/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/ContentView.swift
@@ -226,7 +226,39 @@ struct ContentView: View {
                 return
             }
             
-            let success = await ScreenshotManager.shared.captureViewContent(contentToCapture)
+            // Generate text content based on selected tab
+            let textContent: String
+            switch selectedTab {
+            case 0:
+                if let session = monitor.usageData.activeSession {
+                    let usage = monitor.usageData.sessionUsagePercentage
+                    textContent = """
+                    Claude Code Monitor - Usage Report
+                    
+                    📊 Usage: \(String(format: "%.1f", usage))%
+                    💰 Cost: $\(String(format: "%.2f", session.costUSD))
+                    🔥 Burn Rate: \(monitor.usageData.sessionBurnRate) tokens/min
+                    ⏱️ Time Until Reset: \(monitor.usageData.sessionRemainingTime)
+                    
+                    #ClaudeCode #AIProductivity #DeveloperTools
+                    """
+                } else {
+                    textContent = "Claude Code Monitor - No active session\n\n#ClaudeCode #AIProductivity"
+                }
+            case 1:
+                let totalCost = monitor.usageData.monthlyTotal?.totalCost ?? 0.0
+                textContent = """
+                Claude Code Monitor - History
+                
+                💸 Monthly Total Cost: $\(String(format: "%.2f", totalCost))
+                
+                #ClaudeCode #AIProductivity #DeveloperTools
+                """
+            default:
+                textContent = ""
+            }
+            
+            let success = await ScreenshotManager.shared.captureViewContent(contentToCapture, withText: textContent)
             if success {
                 // Show visual feedback
                 showCopiedFeedback = true

--- a/Sources/ClaudeUsageMonitor/Localization.swift
+++ b/Sources/ClaudeUsageMonitor/Localization.swift
@@ -231,4 +231,20 @@ struct L10n {
     static var claudeDataFolderMessage: String { "claudeDataFolderMessage".localized }
     static var invalidClaudeFolder: String { "invalidClaudeFolder".localized }
     static var failedToSaveAccess: String { "failedToSaveAccess".localized }
+    
+    // Share Text
+    struct Share {
+        static var hashtags: String { "share.hashtags".localized }
+        
+        struct CurrentSession {
+            static var consuming: String { "share.currentSession.consuming".localized }
+            static var noSession: String { "share.currentSession.noSession".localized }
+        }
+        
+        struct History {
+            static var title: String { "share.history.title".localized }
+            static var today: String { "share.history.today".localized }
+            static var month: String { "share.history.month".localized }
+        }
+    }
 }

--- a/Sources/ClaudeUsageMonitor/Localization.swift
+++ b/Sources/ClaudeUsageMonitor/Localization.swift
@@ -238,6 +238,7 @@ struct L10n {
         
         struct CurrentSession {
             static var consuming: String { "share.currentSession.consuming".localized }
+            static var resetIn: String { "share.currentSession.resetIn".localized }
             static var noSession: String { "share.currentSession.noSession".localized }
         }
         

--- a/Sources/ClaudeUsageMonitor/Localization.swift
+++ b/Sources/ClaudeUsageMonitor/Localization.swift
@@ -99,6 +99,9 @@ struct L10n {
         static func used(percentage: String) -> String {
             return "session.used".localized(with: percentage)
         }
+        static func tokensConsumed(tokens: String) -> String {
+            return "session.tokensConsumed".localized(with: tokens)
+        }
         static func resetTime(time: String) -> String {
             return "session.resetTime".localized(with: time)
         }

--- a/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
@@ -23,6 +23,7 @@
 "session.waitingForData" = "Waiting for data...";
 "session.highUsageWarning" = "High usage rate";
 "session.used" = "%@ Used";
+"session.tokensConsumed" = "%@ tokens consumed";
 "session.resetTime" = "Reset: %@";
 "session.sessionDetails" = "Session Details (5-hour session)";
 "session.plan" = "Plan:";

--- a/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
@@ -118,3 +118,11 @@
 "claudeDataFolderMessage" = "This app needs access to your Claude data folder.\n\nThe folder should already be selected (~/.claude).\nJust click 'Grant Access' to continue.";
 "invalidClaudeFolder" = "The selected folder doesn't appear to be a valid Claude data folder. Please make sure it contains a 'projects' subdirectory.";
 "failedToSaveAccess" = "Failed to save folder access. Please try again.";
+
+// Share Text
+"share.currentSession.consuming" = "Currently consuming %@ tokens ($%@) 🔥";
+"share.currentSession.noSession" = "No active Claude Code session";
+"share.history.title" = "Claude Code Usage 📊";
+"share.history.today" = "Today: %@ tokens ($%@)";
+"share.history.month" = "Month: %@ tokens ($%@)";
+"share.hashtags" = "#ClaudeCodeMonitor";

--- a/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 
 // Share Text
 "share.currentSession.consuming" = "Currently consuming %@ tokens ($%@) 🔥";
+"share.currentSession.resetIn" = "Reset in %@ ⏰";
 "share.currentSession.noSession" = "No active Claude Code session";
 "share.history.title" = "Claude Code Usage 📊";
 "share.history.today" = "Today: %@ tokens ($%@)";

--- a/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
@@ -23,6 +23,7 @@
 "session.waitingForData" = "データを取得中...";
 "session.highUsageWarning" = "使用率が高い";
 "session.used" = "%@ 使用済み";
+"session.tokensConsumed" = "%@トークン消費";
 "session.resetTime" = "リセット: %@";
 "session.sessionDetails" = "Session Details (5時間セッション)";
 "session.plan" = "プラン:";

--- a/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 
 // Share Text
 "share.currentSession.consuming" = "現在%@トークン($%@)を消費中🔥";
+"share.currentSession.resetIn" = "リセットまで残り%@ ⏰";
 "share.currentSession.noSession" = "アクティブなClaude Codeセッションがありません";
 "share.history.title" = "Claude Code使用状況 📊";
 "share.history.today" = "今日: %@トークン ($%@)";

--- a/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
@@ -118,3 +118,11 @@
 "claudeDataFolderMessage" = "このアプリはClaudeのデータフォルダへのアクセスが必要です。\n\nフォルダは既に選択されています（~/.claude）。\n「アクセスを許可」をクリックして続行してください。";
 "invalidClaudeFolder" = "選択されたフォルダは有効なClaudeデータフォルダではないようです。'projects'サブディレクトリが含まれていることを確認してください。";
 "failedToSaveAccess" = "フォルダアクセスの保存に失敗しました。もう一度お試しください。";
+
+// Share Text
+"share.currentSession.consuming" = "現在%@トークン($%@)を消費中🔥";
+"share.currentSession.noSession" = "アクティブなClaude Codeセッションがありません";
+"share.history.title" = "Claude Code使用状況 📊";
+"share.history.today" = "今日: %@トークン ($%@)";
+"share.history.month" = "今月: %@トークン ($%@)";
+"share.hashtags" = "#ClaudeCodeMonitor";

--- a/Sources/ClaudeUsageMonitor/SessionModels.swift
+++ b/Sources/ClaudeUsageMonitor/SessionModels.swift
@@ -181,6 +181,34 @@ extension UsageData {
             return "\(minutes)m"
         }
     }
+    
+    // Share text用のシンプルな残り時間表示
+    var sessionRemainingTimeForShare: String {
+        guard let session = activeSession,
+              let projection = session.projection else { return "N/A" }
+
+        let totalMinutes = projection.remainingMinutes
+        let hours = totalMinutes / 60
+        let minutes = totalMinutes % 60
+        
+        // 英語環境かどうかを判定
+        let isEnglish = LanguageSettings.shared.effectiveLanguageCode() == "en"
+
+        if hours > 0 {
+            if minutes == 0 {
+                return isEnglish ? "\(hours)h" : "\(hours)時間"
+            } else {
+                return isEnglish ? "\(hours)h \(minutes)m" : "\(hours)時間\(minutes)分"
+            }
+        } else if minutes > 1 {
+            return isEnglish ? "\(minutes)m" : "\(minutes)分"
+        } else if minutes == 1 {
+            // 1分以下の場合は秒で表示
+            return isEnglish ? "60s" : "60秒"
+        } else {
+            return isEnglish ? "Soon" : "まもなく"
+        }
+    }
 
     var sessionBurnRate: String {
         guard let session = activeSession,

--- a/Sources/ClaudeUsageMonitor/Utils/ScreenshotManager.swift
+++ b/Sources/ClaudeUsageMonitor/Utils/ScreenshotManager.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+import AppKit
+
+@MainActor
+class ScreenshotManager {
+    static let shared = ScreenshotManager()
+    
+    private init() {}
+    
+    func captureViewContent(_ view: AnyView) async -> Bool {
+        // Use ImageRenderer to capture the specific view content
+        let renderer = ImageRenderer(content: view)
+        
+        // Set the scale to match the screen
+        renderer.scale = NSScreen.main?.backingScaleFactor ?? 2.0
+        
+        // Create NSImage from the renderer
+        guard let nsImage = renderer.nsImage else {
+            print("Failed to create screenshot")
+            return false
+        }
+        
+        // Copy to clipboard
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        
+        // Add both PNG and TIFF representations for better compatibility
+        var items: [NSPasteboardItem] = []
+        let item = NSPasteboardItem()
+        
+        if let tiffData = nsImage.tiffRepresentation {
+            item.setData(tiffData, forType: .tiff)
+        }
+        
+        if let tiffData = nsImage.tiffRepresentation,
+           let bitmapRep = NSBitmapImageRep(data: tiffData),
+           let pngData = bitmapRep.representation(using: .png, properties: [:]) {
+            item.setData(pngData, forType: .png)
+        }
+        
+        items.append(item)
+        
+        return pasteboard.writeObjects(items)
+    }
+    
+    func captureAndCopyToClipboard<Content: View>(from view: Content) async -> Bool {
+        // Find the current window's content view
+        guard let window = NSApp.windows.first(where: { $0.isVisible }),
+              let contentView = window.contentView else {
+            print("No visible window found")
+            return false
+        }
+        
+        // Create bitmap representation of the content view
+        guard let bitmapRep = contentView.bitmapImageRepForCachingDisplay(in: contentView.bounds) else {
+            print("Failed to create bitmap representation")
+            return false
+        }
+        
+        // Draw the view into the bitmap
+        contentView.cacheDisplay(in: contentView.bounds, to: bitmapRep)
+        
+        // Create NSImage from bitmap
+        let image = NSImage(size: contentView.bounds.size)
+        image.addRepresentation(bitmapRep)
+        
+        // Copy to clipboard
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        
+        // Add both PNG and TIFF representations for better compatibility
+        var items: [NSPasteboardItem] = []
+        let item = NSPasteboardItem()
+        
+        if let tiffData = image.tiffRepresentation {
+            item.setData(tiffData, forType: .tiff)
+        }
+        
+        if let pngData = bitmapRep.representation(using: .png, properties: [:]) {
+            item.setData(pngData, forType: .png)
+        }
+        
+        items.append(item)
+        
+        return pasteboard.writeObjects(items)
+    }
+    
+    func captureAndShare<Content: View>(from view: Content) async {
+        // Wrap the view with a background to ensure proper rendering
+        let wrappedView = ZStack {
+            // Add explicit background
+            Color(NSColor.windowBackgroundColor)
+                .ignoresSafeArea()
+            
+            view
+        }
+        .frame(width: 380, height: 480) // Match ContentView frame
+
+        let renderer = ImageRenderer(content: wrappedView)
+        
+        // Set the scale to match the screen
+        renderer.scale = NSScreen.main?.backingScaleFactor ?? 2.0
+        
+        // Create NSImage from the renderer
+        guard let nsImage = renderer.nsImage else {
+            print("Failed to create screenshot")
+            return
+        }
+        
+        // Create sharing picker
+        let picker = NSSharingServicePicker(items: [nsImage])
+        
+        // Find a suitable view to anchor the picker
+        guard let window = NSApp.windows.first(where: { $0.isVisible }),
+              let contentView = window.contentView else {
+            print("No visible window found")
+            return
+        }
+        
+        // Show the picker
+        let rect = NSRect(x: contentView.bounds.midX - 1, y: contentView.bounds.midY - 1, width: 2, height: 2)
+        picker.show(relativeTo: rect, of: contentView, preferredEdge: .minY)
+    }
+}

--- a/Sources/ClaudeUsageMonitor/Utils/ScreenshotManager.swift
+++ b/Sources/ClaudeUsageMonitor/Utils/ScreenshotManager.swift
@@ -7,7 +7,7 @@ class ScreenshotManager {
     
     private init() {}
     
-    func captureViewContent(_ view: AnyView) async -> Bool {
+    func captureViewContent(_ view: AnyView, withText text: String? = nil) async -> Bool {
         // Use ImageRenderer to capture the specific view content
         let renderer = ImageRenderer(content: view)
         
@@ -24,10 +24,11 @@ class ScreenshotManager {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         
-        // Add both PNG and TIFF representations for better compatibility
+        // Create pasteboard items
         var items: [NSPasteboardItem] = []
         let item = NSPasteboardItem()
         
+        // Add image data
         if let tiffData = nsImage.tiffRepresentation {
             item.setData(tiffData, forType: .tiff)
         }
@@ -36,6 +37,11 @@ class ScreenshotManager {
            let bitmapRep = NSBitmapImageRep(data: tiffData),
            let pngData = bitmapRep.representation(using: .png, properties: [:]) {
             item.setData(pngData, forType: .png)
+        }
+        
+        // Add text if provided
+        if let text = text {
+            item.setString(text, forType: .string)
         }
         
         items.append(item)


### PR DESCRIPTION
## 概要
Claude Code Monitorの使用状況をスクリーンショットとテキストで簡単に共有できる機能を追加しました。

## 変更内容

### 🎯 主な機能
- **スクリーンショット共有機能**
  - CurrentタブとHistoryタブでスクリーンショットをクリップボードにコピー
  - ⌘Sのキーボードショートカットで素早くアクセス
  - コピー成功時にチェックマークアイコンでフィードバック表示

- **テキスト同時コピー**
  - 画像と一緒にSNS投稿用のテキストも自動生成
  - シンプルで共有しやすい内容に最適化
  - 多言語対応（日本語/英語）

### 📝 共有テキストの例

**現在タブ:**
```
現在30.5Kトークン($48.83)を消費中🔥
リセットまで残り1時間24分 ⏰

#ClaudeCodeMonitor
```

**履歴タブ:**
```
Claude Code使用状況 📊
今日: 11.2Kトークン ($29.92)
今月: 54.5Kトークン ($89.54)

#ClaudeCodeMonitor
```

### 🛠 技術的な詳細
- `ScreenshotManager.swift`: スクリーンショット生成とクリップボード操作
- `ImageRenderer`を使用してSwiftUIビューを画像化
- ダークモード/ライトモードの両方に対応
- 残り時間の表示は状況に応じて適切にフォーマット（1分未満は秒表示など）

### 🐛 修正内容
- 履歴タブの共有テキストで`billableTokens`を使用（キャッシュトークンを除外）
- CurrentSessionViewに消費トークン数を表示追加（共有テキストとUIの一致）

### 📸 UI改善
- プログレスバーの下に「7.2% Used • 10.1K tokens consumed」形式で表示
- 視覚的な階層を保ちつつ、必要な情報を追加

## テスト方法
1. アプリを起動
2. CurrentまたはHistoryタブを表示
3. ⌘Sを押すか、共有ボタンをクリック
4. 任意のアプリに貼り付けて画像とテキストが正しくコピーされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)