### PR TITLE
Claude Codeインストールリンクを言語別のドキュメントページに修正

### DIFF
--- a/Sources/ClaudeUsageMonitor/ClaudeNotInstalledView.swift
+++ b/Sources/ClaudeUsageMonitor/ClaudeNotInstalledView.swift
@@ -1,6 +1,13 @@
 import SwiftUI
 
 struct ClaudeNotInstalledView: View {
+    @StateObject private var languageSettings = LanguageSettings.shared
+    
+    private var setupURL: String {
+        let langCode = languageSettings.currentLanguage == .japanese ? "ja" : "en"
+        return "https://docs.anthropic.com/\(langCode)/docs/claude-code/setup"
+    }
+    
     var body: some View {
         VStack(spacing: 20) {
             Image(systemName: "exclamationmark.circle")
@@ -17,7 +24,7 @@ struct ClaudeNotInstalledView: View {
                 .padding(.horizontal)
             
             Button(action: {
-                if let url = URL(string: "https://claude.ai/download") {
+                if let url = URL(string: setupURL) {
                     NSWorkspace.shared.open(url)
                 }
             }) {


### PR DESCRIPTION
## Summary
Claude Code未インストール時のエラー画面で表示されるインストールリンクを、言語設定に応じた適切なドキュメントページへ変更

## Changes
- `ClaudeNotInstalledView.swift`に言語設定機能を追加
- 現在の言語設定に基づいて適切なURLを生成する`setupURL`プロパティを実装
- ボタンクリック時に言語に応じたセットアップページを開くように修正

## URLs
- 英語: https://docs.anthropic.com/en/docs/claude-code/setup
- 日本語: https://docs.anthropic.com/ja/docs/claude-code/setup

## Test plan
- [ ] 日本語設定で「Install Claude Code」ボタンをクリックすると日本語のセットアップページが開くことを確認
- [ ] 英語設定で「Install Claude Code」ボタンをクリックすると英語のセットアップページが開くことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)