### PR TITLE
fix: リリースビルドでのクラッシュを修正

### DIFF
--- a/Sources/ClaudeUsageMonitor/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
 
                     HStack {
                         HStack(spacing: 4) {
-                            Image("AppLogo", bundle: .module)
+                            Image("AppLogo", bundle: ResourceBundle.current)
                                 .resizable()
                                 .scaledToFit()
                                 .frame(width: 20, height: 20)

--- a/Sources/ClaudeUsageMonitor/Localization.swift
+++ b/Sources/ClaudeUsageMonitor/Localization.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 
 // MARK: - Resource Bundle Helper
-private struct ResourceBundle {
+struct ResourceBundle {
     static let current: Bundle = {
         let bundleName = "ClaudeCodeMonitor_ClaudeCodeMonitor.bundle"
 
@@ -29,8 +29,8 @@ private struct ResourceBundle {
             }
         }
 
-        // Fallback: use the auto-generated Bundle.module
-        return Bundle.module
+        // Fallback: use main bundle
+        return Bundle.main
     }()
 }
 


### PR DESCRIPTION
## Summary
リリースビルド（v0.4.6）でアイコンをタップするとクラッシュする問題を修正しました。

## Problem
```
_assertionFailure(_:_:file:line:flags:)
closure #1 in variable initialization expression of static NSBundle.module
```

`Bundle.module`はSPMの開発時のみ使用可能な機能で、リリースビルドでは使用できないためクラッシュしていました。

## Solution
1. `ResourceBundle`構造体をpublicに変更
2. `Image("AppLogo", bundle: .module)`を`Image("AppLogo", bundle: ResourceBundle.current)`に変更
3. `Bundle.module`へのフォールバックを`Bundle.main`に変更

## Test plan
- [x] ローカルビルドで動作確認
- [ ] リリースビルドでクラッシュしないことを確認
- [ ] アイコンが正しく表示されることを確認

## Impact
この問題は現在リリースされているv0.4.6で発生しているため、緊急修正が必要です。

🤖 Generated with [Claude Code](https://claude.ai/code)