### PR TITLE
fix: リリースビルドでのクラッシュを修正（ヘッダーアイコンを削除）

### DIFF
--- a/Sources/ClaudeUsageMonitor/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/ContentView.swift
@@ -26,14 +26,8 @@ struct ContentView: View {
                         .frame(height: 44)
 
                     HStack {
-                        HStack(spacing: 4) {
-                            Image("AppLogo", bundle: ResourceBundle.current)
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 20, height: 20)
-                            Text("ClaudeCodeMonitor")
-                                .font(.system(size: 14, weight: .semibold))
-                        }
+                        Text("ClaudeCodeMonitor")
+                            .font(.system(size: 14, weight: .semibold))
 
                         Spacer()
 


### PR DESCRIPTION
## Summary
リリースビルドでアイコンをタップするとクラッシュする問題を修正しました。

## Problem
`Bundle.module`はSPMの開発時のみ使用可能な機能で、リリースビルドでは使用できないためクラッシュしていました。

## Solution
ContentViewのヘッダーからアイコンを削除し、テキストのみのシンプルな表示に変更しました。

## Test plan
- [x] ローカルビルドで動作確認
- [ ] リリースビルドでクラッシュしないことを確認

## Impact
現在リリースされているバージョンで発生している問題のため、緊急修正が必要です。

🤖 Generated with [Claude Code](https://claude.ai/code)