### PR TITLE
feat: add Sparkle framework for automatic updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,6 +299,23 @@ jobs:
         xcrun stapler staple "$DMG_PATH"
         xcrun stapler validate "$DMG_PATH"
     
+    # Generate Sparkle appcast.xml
+    - name: Generate Sparkle appcast.xml
+      if: env.SPARKLE_PRIVATE_KEY != ''
+      env:
+        SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        echo "🔏 Generating Sparkle appcast.xml..."
+        ./scripts/generate-appcast.sh
+        
+        if [ -f "appcast.xml" ]; then
+          echo "✅ Successfully generated appcast.xml"
+        else
+          echo "❌ Failed to generate appcast.xml"
+          exit 1
+        fi
+    
     # Generate changelog
     - name: Generate changelog
       id: changelog
@@ -343,7 +360,9 @@ jobs:
         body: ${{ steps.changelog.outputs.changelog }}
         draft: false
         prerelease: false
-        files: ${{ env.DMG_PATH }}
+        files: |
+          ${{ env.DMG_PATH }}
+          appcast.xml
     
     # Cleanup
     - name: Clean up keychain

--- a/Info.plist
+++ b/Info.plist
@@ -30,5 +30,13 @@
 	<true/>
 	<key>NSUserNotificationAlertStyle</key>
 	<string>banner</string>
+	<key>SUFeedURL</key>
+	<string>https://github.com/K9i-0/ClaudeCodeMonitor/releases/latest/download/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>PLACEHOLDER_PUBLIC_KEY</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>86400</integer>
 </dict>
 </plist>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "df074165274afaa39539c05d57b0832620775b11",
+        "version" : "2.7.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,15 @@ let package = Package(
             targets: ["ClaudeCodeMonitor"]
         )
     ],
+    dependencies: [
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.5.2")
+    ],
     targets: [
         .executableTarget(
             name: "ClaudeCodeMonitor",
+            dependencies: [
+                .product(name: "Sparkle", package: "Sparkle")
+            ],
             path: "Sources/ClaudeUsageMonitor",
             resources: [
                 .process("Resources/en.lproj"),

--- a/Sources/ClaudeUsageMonitor/App/AppDelegate.swift
+++ b/Sources/ClaudeUsageMonitor/App/AppDelegate.swift
@@ -2,6 +2,7 @@ import Cocoa
 import SwiftUI
 import Combine
 import UserNotifications
+import Sparkle
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem!
@@ -10,6 +11,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var usageMonitor: UsageMonitor!
     private var environmentCheckResult = EnvironmentCheckResult()
     private var isEnvironmentValid = false
+    private let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Debug builds use different settings to avoid conflicts with release version

--- a/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
@@ -143,3 +143,14 @@
 "share.history.today" = "Today: %@ tokens ($%@)";
 "share.history.month" = "Month: %@ tokens ($%@)";
 "share.hashtags" = "#ClaudeCodeMonitor";
+
+// Updates
+"update.settings" = "Update Settings";
+"update.checkForUpdates" = "Check for Updates";
+"update.automaticUpdates" = "Automatic Updates";
+"update.automaticUpdatesDescription" = "Check for updates automatically";
+"update.currentVersion" = "Current Version: %@";
+"update.checking" = "Checking for updates...";
+"update.upToDate" = "You're up to date!";
+"update.available" = "Update available";
+"update.failed" = "Failed to check for updates";

--- a/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
@@ -143,3 +143,14 @@
 "share.history.today" = "今日: %@トークン ($%@)";
 "share.history.month" = "今月: %@トークン ($%@)";
 "share.hashtags" = "#ClaudeCodeMonitor";
+
+// Updates
+"update.settings" = "アップデート設定";
+"update.checkForUpdates" = "アップデートを確認";
+"update.automaticUpdates" = "自動アップデート";
+"update.automaticUpdatesDescription" = "アップデートを自動的に確認する";
+"update.currentVersion" = "現在のバージョン: %@";
+"update.checking" = "アップデートを確認中...";
+"update.upToDate" = "最新の状態です！";
+"update.available" = "アップデートがあります";
+"update.failed" = "アップデート確認に失敗しました";

--- a/Sources/ClaudeUsageMonitor/Views/Tabs/SettingsTabView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/Tabs/SettingsTabView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
+import Sparkle
 
 struct SettingsTabView: View {
     @EnvironmentObject var monitor: UsageMonitor
     @StateObject private var languageSettings = LanguageSettings.shared
     // @State private var notificationEnabled = Bundle.main.bundleIdentifier != nil ? NotificationManager.shared.isNotificationEnabled : false
+    private let updater = SPUStandardUpdaterController(startingUpdater: false, updaterDelegate: nil, userDriverDelegate: nil).updater
 
     let plans = [
         ("Pro", "7,000 tokens/session", L10n.Plan.pro),
@@ -119,6 +121,55 @@ struct SettingsTabView: View {
                 }
             }
             */
+
+            Divider()
+
+            // Update settings section
+            VStack(alignment: .leading, spacing: 12) {
+                Text(L10n.Update.settings)
+                    .font(.system(size: 16, weight: .semibold))
+
+                // Current version
+                HStack {
+                    Text(L10n.Update.currentVersion(Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"))
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                    Spacer()
+                }
+                .padding(.bottom, 4)
+
+                // Check for updates button
+                Button(action: {
+                    updater.checkForUpdates()
+                }) {
+                    HStack {
+                        Image(systemName: "arrow.triangle.2.circlepath")
+                            .font(.system(size: 14))
+                        Text(L10n.Update.checkForUpdates)
+                            .font(.system(size: 14))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+                    .background(Color.accentColor.opacity(0.1))
+                    .cornerRadius(6)
+                }
+                .buttonStyle(PlainButtonStyle())
+
+                // Automatic updates toggle
+                Toggle(isOn: .init(
+                    get: { updater.automaticallyChecksForUpdates },
+                    set: { updater.automaticallyChecksForUpdates = $0 }
+                )) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(L10n.Update.automaticUpdates)
+                            .font(.system(size: 14))
+                        Text(L10n.Update.automaticUpdatesDescription)
+                            .font(.system(size: 12))
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .toggleStyle(SwitchToggleStyle(tint: .accentColor))
+            }
 
             #if DEBUG
             Divider()

--- a/docs/sparkle-setup.md
+++ b/docs/sparkle-setup.md
@@ -1,0 +1,126 @@
+# Sparkle Setup Guide
+
+This guide explains how to set up Sparkle for automatic updates in ClaudeCodeMonitor.
+
+## Prerequisites
+
+- macOS with Homebrew installed
+- Access to the GitHub repository secrets
+
+## Initial Setup (One-time only)
+
+### 1. Install Sparkle Tools
+
+```bash
+# Download Sparkle
+curl -L -o sparkle.tar.xz https://github.com/sparkle-project/Sparkle/releases/download/2.5.2/Sparkle-2.5.2.tar.xz
+tar -xf sparkle.tar.xz
+
+# The tools will be in Sparkle.framework/Versions/Current/Resources/
+```
+
+### 2. Generate EdDSA Key Pair
+
+```bash
+# Navigate to Sparkle tools directory
+cd Sparkle.framework/Versions/Current/Resources/
+
+# Generate key pair
+./generate_keys
+
+# This will output:
+# - Public key (EdDSA)
+# - Private key (EdDSA)
+```
+
+### 3. Configure Public Key
+
+1. Copy the public key from the output
+2. Update `Info.plist`:
+   ```xml
+   <key>SUPublicEDKey</key>
+   <string>YOUR_PUBLIC_KEY_HERE</string>
+   ```
+3. Commit and push this change
+
+### 4. Configure Private Key
+
+1. Go to GitHub repository settings
+2. Navigate to Settings → Secrets and variables → Actions
+3. Create a new repository secret named `SPARKLE_PRIVATE_KEY`
+4. Paste the private key (including the entire line)
+
+## How It Works
+
+### Release Process
+
+When a PR is merged to main:
+
+1. The release workflow creates a new version
+2. Builds and signs the app
+3. Creates a DMG file
+4. If `SPARKLE_PRIVATE_KEY` is set:
+   - Generates EdDSA signature for the DMG
+   - Creates `appcast.xml` with update information
+   - Uploads both DMG and appcast.xml to GitHub Release
+
+### Update Check
+
+1. ClaudeCodeMonitor checks the appcast.xml URL periodically
+2. If a new version is found, it verifies the EdDSA signature
+3. Prompts user to download and install the update
+
+### appcast.xml Location
+
+The appcast.xml file is available at:
+```
+https://github.com/K9i-0/ClaudeCodeMonitor/releases/latest/download/appcast.xml
+```
+
+## Security Notes
+
+- **Never commit the private key** to the repository
+- The private key should only be stored in GitHub Secrets
+- The public key is safe to commit and share
+- EdDSA signatures ensure updates haven't been tampered with
+
+## Testing Updates
+
+To test the update mechanism:
+
+1. Build a test version with a lower version number
+2. Run the app
+3. Check for updates from Settings → Update Settings
+4. Verify that the app detects the newer version
+
+## Troubleshooting
+
+### "No updates available" when there should be
+
+1. Check that `SUFeedURL` in Info.plist is correct
+2. Verify appcast.xml exists at the URL
+3. Check Console.app for Sparkle-related errors
+
+### Signature verification failed
+
+1. Ensure the public key in Info.plist matches the one used to generate signatures
+2. Verify the private key in GitHub Secrets is correct
+3. Check that the DMG hasn't been modified after signing
+
+## Manual Key Generation (Alternative)
+
+If you need to generate keys manually:
+
+```bash
+# Generate private key
+openssl genpkey -algorithm ed25519 -out private_key.pem
+
+# Extract public key
+openssl pkey -in private_key.pem -pubout -out public_key.pem
+
+# Convert to Sparkle format (base64)
+cat private_key.pem | openssl base64 -A
+cat public_key.pem | openssl base64 -A
+```
+
+Note: Use the Sparkle-provided `generate_keys` tool for best compatibility.

--- a/scripts/generate-appcast.sh
+++ b/scripts/generate-appcast.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# This script generates the appcast.xml file for Sparkle updates
+
+# Check if the required environment variables are set
+if [ -z "${SPARKLE_PRIVATE_KEY:-}" ]; then
+    echo "Error: SPARKLE_PRIVATE_KEY environment variable is not set"
+    exit 1
+fi
+
+if [ -z "${VERSION:-}" ]; then
+    echo "Error: VERSION environment variable is not set"
+    exit 1
+fi
+
+if [ -z "${DMG_PATH:-}" ]; then
+    echo "Error: DMG_PATH environment variable is not set"
+    exit 1
+fi
+
+# GitHub repository information
+REPO_URL="https://github.com/K9i-0/ClaudeCodeMonitor"
+DOWNLOAD_URL="${REPO_URL}/releases/download/v${VERSION}/ClaudeCodeMonitor-${VERSION}.dmg"
+
+# Get file size and date
+FILE_SIZE=$(stat -f%z "$DMG_PATH")
+RELEASE_DATE=$(date -u +"%a, %d %b %Y %H:%M:%S %z")
+
+# Create temporary directory for Sparkle tools
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Download Sparkle tools if not available
+SPARKLE_VERSION="2.5.2"
+SPARKLE_TOOLS_URL="https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+
+echo "Downloading Sparkle tools..."
+curl -L -o "$TEMP_DIR/sparkle.tar.xz" "$SPARKLE_TOOLS_URL"
+tar -xf "$TEMP_DIR/sparkle.tar.xz" -C "$TEMP_DIR"
+
+# Path to sign_update tool
+SIGN_UPDATE="$TEMP_DIR/Sparkle.framework/Versions/Current/Resources/sign_update"
+
+if [ ! -f "$SIGN_UPDATE" ]; then
+    echo "Error: sign_update tool not found at $SIGN_UPDATE"
+    exit 1
+fi
+
+# Generate EdDSA signature
+echo "Generating signature for $DMG_PATH..."
+SIGNATURE=$("$SIGN_UPDATE" -f "$SPARKLE_PRIVATE_KEY" "$DMG_PATH" | tail -1)
+
+if [ -z "$SIGNATURE" ]; then
+    echo "Error: Failed to generate signature"
+    exit 1
+fi
+
+# Generate appcast.xml
+cat > appcast.xml << EOF
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>Claude Code Monitor Changelog</title>
+        <link>${REPO_URL}/releases/latest/download/appcast.xml</link>
+        <description>Most recent changes with links to updates.</description>
+        <language>en</language>
+        <item>
+            <title>Version ${VERSION}</title>
+            <pubDate>${RELEASE_DATE}</pubDate>
+            <enclosure url="${DOWNLOAD_URL}"
+                       sparkle:version="${VERSION}"
+                       sparkle:shortVersionString="${VERSION}"
+                       length="${FILE_SIZE}"
+                       type="application/octet-stream"
+                       sparkle:edSignature="${SIGNATURE}" />
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+        </item>
+    </channel>
+</rss>
+EOF
+
+echo "Successfully generated appcast.xml for version ${VERSION}"
+echo "Signature: ${SIGNATURE}"

--- a/scripts/sign-update.sh
+++ b/scripts/sign-update.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# This script signs a release file with Sparkle's EdDSA signature
+
+# Check if the required arguments are provided
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <file-to-sign>"
+    exit 1
+fi
+
+FILE_TO_SIGN="$1"
+
+# Check if the file exists
+if [ ! -f "$FILE_TO_SIGN" ]; then
+    echo "Error: File not found: $FILE_TO_SIGN"
+    exit 1
+fi
+
+# Check if the required environment variable is set
+if [ -z "${SPARKLE_PRIVATE_KEY:-}" ]; then
+    echo "Error: SPARKLE_PRIVATE_KEY environment variable is not set"
+    exit 1
+fi
+
+# Create temporary directory for Sparkle tools
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Download Sparkle tools if not available
+SPARKLE_VERSION="2.5.2"
+SPARKLE_TOOLS_URL="https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+
+echo "Downloading Sparkle tools..."
+curl -L -o "$TEMP_DIR/sparkle.tar.xz" "$SPARKLE_TOOLS_URL"
+tar -xf "$TEMP_DIR/sparkle.tar.xz" -C "$TEMP_DIR"
+
+# Path to sign_update tool
+SIGN_UPDATE="$TEMP_DIR/Sparkle.framework/Versions/Current/Resources/sign_update"
+
+if [ ! -f "$SIGN_UPDATE" ]; then
+    echo "Error: sign_update tool not found at $SIGN_UPDATE"
+    exit 1
+fi
+
+# Generate EdDSA signature
+echo "Generating signature for $FILE_TO_SIGN..."
+SIGNATURE=$("$SIGN_UPDATE" -f "$SPARKLE_PRIVATE_KEY" "$FILE_TO_SIGN" | tail -1)
+
+if [ -z "$SIGNATURE" ]; then
+    echo "Error: Failed to generate signature"
+    exit 1
+fi
+
+echo "Signature: $SIGNATURE"
+
+# Export for use in other scripts
+export SPARKLE_SIGNATURE="$SIGNATURE"


### PR DESCRIPTION
## Summary
- Sparkle 2.5.2を導入して自動アップデート機能を実装
- 設定タブにアップデート確認UIを追加
- リリースワークフローにappcast.xml生成を統合

## Changes
### Dependencies
- Package.swiftにSparkle依存関係を追加

### UI/UX
- 設定タブに「アップデート設定」セクションを追加
  - 現在のバージョン表示
  - 「アップデートを確認」ボタン
  - 自動アップデートのトグル

### Infrastructure
- `scripts/generate-appcast.sh`: appcast.xml生成スクリプト
- `scripts/sign-update.sh`: Sparkle用EdDSA署名スクリプト
- release.ymlワークフローにSparkleステップを追加

### Documentation
- `docs/sparkle-setup.md`: 詳細なセットアップガイド

## Setup Required
このPRをマージ後、以下の手動作業が必要です：

1. Sparkleキーペアの生成（docs/sparkle-setup.md参照）
2. 公開鍵をInfo.plistに設定
3. 秘密鍵をGitHub Secretsに`SPARKLE_PRIVATE_KEY`として登録

## Test plan
- [x] Xcode開発環境でビルド確認
- [ ] 設定タブのUIが正しく表示されることを確認
- [ ] 「アップデートを確認」ボタンが動作することを確認
- [ ] リリースワークフローが正常に動作することを確認（秘密鍵設定後）

## Notes
- 初回リリースではSparkleは動作しません（比較するバージョンがないため）
- v0.2.0以降から自動アップデート機能が有効になります

🤖 Generated with [Claude Code](https://claude.ai/code)