### PR TITLE
feat: improve History tab design with colorful cards and better layout

### DIFF
--- a/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
@@ -104,6 +104,7 @@
 "history.dailyAverage" = "Daily Average";
 "history.peak" = "Peak";
 "history.today" = "Today";
+"history.perDay" = "per day";
 "status.usageFormat" = "Usage: %.1f%%\nCost: $%.2f\nBurn rate: %.0f tokens/min\nTime remaining: %@";
 
 // Notifications

--- a/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
@@ -97,6 +97,13 @@
 "status.lastUpdated" = "Updated: %@";
 "status.loading" = "Loading usage data...";
 "status.noActiveSession" = "No active session";
+
+// History
+"history.monthSummary" = "Monthly Summary";
+"history.total" = "Total";
+"history.dailyAverage" = "Daily Average";
+"history.peak" = "Peak";
+"history.today" = "Today";
 "status.usageFormat" = "Usage: %.1f%%\nCost: $%.2f\nBurn rate: %.0f tokens/min\nTime remaining: %@";
 
 // Notifications

--- a/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
@@ -150,3 +150,4 @@
 "history.dailyAverage" = "日次平均";
 "history.peak" = "ピーク";
 "history.today" = "今日";
+"history.perDay" = "日額";

--- a/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
@@ -143,3 +143,10 @@
 "share.history.today" = "今日: %@トークン ($%@)";
 "share.history.month" = "今月: %@トークン ($%@)";
 "share.hashtags" = "#ClaudeCodeMonitor";
+
+// History
+"history.monthSummary" = "月間サマリー";
+"history.total" = "合計";
+"history.dailyAverage" = "日次平均";
+"history.peak" = "ピーク";
+"history.today" = "今日";

--- a/Sources/ClaudeUsageMonitor/Utils/Localization.swift
+++ b/Sources/ClaudeUsageMonitor/Utils/Localization.swift
@@ -128,6 +128,11 @@ struct L10n {
         static var time: String { "history.time".localized }
         static var tokens: String { "history.tokens".localized }
         static var noData: String { "history.noData".localized }
+        static var monthSummary: String { "history.monthSummary".localized }
+        static var total: String { "history.total".localized }
+        static var dailyAverage: String { "history.dailyAverage".localized }
+        static var peak: String { "history.peak".localized }
+        static var today: String { "history.today".localized }
     }
 
     struct Plan {

--- a/Sources/ClaudeUsageMonitor/Utils/Localization.swift
+++ b/Sources/ClaudeUsageMonitor/Utils/Localization.swift
@@ -133,6 +133,7 @@ struct L10n {
         static var dailyAverage: String { "history.dailyAverage".localized }
         static var peak: String { "history.peak".localized }
         static var today: String { "history.today".localized }
+        static var perDay: String { "history.perDay".localized }
     }
 
     struct Plan {

--- a/Sources/ClaudeUsageMonitor/Views/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/ContentView.swift
@@ -252,70 +252,50 @@ struct ContentView: View {
 
                             // 月間サマリー（インライン）
                             if !historyViewModel.dailyData.isEmpty, let totals = historyViewModel.monthlyTotals {
-                                HStack(spacing: 4) {
+                                HStack(spacing: 16) {
                                     // 合計
-                                    HStack(spacing: 12) {
-                                        VStack(spacing: 4) {
-                                            Image(systemName: "chart.bar.fill")
-                                                .font(.system(size: 16))
-                                                .foregroundStyle(.blue)
-                                                .frame(width: 20, height: 20)
-                                            
-                                            Text(L10n.History.total)
-                                                .font(.system(size: 9, weight: .medium))
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        HStack(spacing: 4) {
+                                            Image(systemName: "dollarsign.circle.fill")
+                                                .font(.system(size: 12))
                                                 .foregroundStyle(.secondary)
-                                        }
-                                        
-                                        VStack(alignment: .leading, spacing: 2) {
-                                            Text(String(format: "$%.0f", totals.totalCost))
-                                                .font(.system(size: 16, weight: .semibold, design: .rounded))
-                                                .foregroundStyle(.primary)
-                                            Text("\(NumberFormatters.formatTokens(totals.totalTokens))")
+                                            Text(L10n.History.total)
                                                 .font(.system(size: 11, weight: .medium))
                                                 .foregroundStyle(.secondary)
                                         }
+                                        Text(String(format: "$%.0f", totals.totalCost))
+                                            .font(.system(size: 16, weight: .semibold, design: .rounded))
+                                        Text("\(NumberFormatters.formatTokens(totals.totalTokens))")
+                                            .font(.system(size: 12))
+                                            .foregroundStyle(.secondary)
                                     }
-                                    .padding(.horizontal, 16)
-                                    .padding(.vertical, 10)
-                                    .frame(maxWidth: .infinity)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 10)
-                                            .fill(Color(NSColor.controlBackgroundColor))
-                                            .opacity(0.8)
-                                    )
+                                    
+                                    Divider()
+                                        .frame(height: 36)
                                     
                                     // 日次平均
-                                    HStack(spacing: 12) {
-                                        VStack(spacing: 4) {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        HStack(spacing: 4) {
                                             Image(systemName: "calendar.day.timeline.left")
-                                                .font(.system(size: 16))
-                                                .foregroundStyle(.green)
-                                                .frame(width: 20, height: 20)
-                                            
-                                            Text(L10n.History.dailyAverage)
-                                                .font(.system(size: 9, weight: .medium))
+                                                .font(.system(size: 12))
                                                 .foregroundStyle(.secondary)
-                                        }
-                                        
-                                        VStack(alignment: .leading, spacing: 2) {
-                                            Text(String(format: "$%.0f", totals.totalCost / Double(historyViewModel.dailyData.count)))
-                                                .font(.system(size: 16, weight: .semibold, design: .rounded))
-                                                .foregroundStyle(.primary)
-                                            Text(L10n.History.perDay)
+                                            Text(L10n.History.dailyAverage)
                                                 .font(.system(size: 11, weight: .medium))
                                                 .foregroundStyle(.secondary)
                                         }
+                                        Text(String(format: "$%.0f", totals.totalCost / Double(historyViewModel.dailyData.count)))
+                                            .font(.system(size: 16, weight: .semibold, design: .rounded))
+                                        Text(L10n.History.perDay)
+                                            .font(.system(size: 12))
+                                            .foregroundStyle(.secondary)
                                     }
-                                    .padding(.horizontal, 16)
-                                    .padding(.vertical, 10)
-                                    .frame(maxWidth: .infinity)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 10)
-                                            .fill(Color(NSColor.controlBackgroundColor))
-                                            .opacity(0.8)
-                                    )
                                 }
-                                .padding(.horizontal, 2)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 10)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .fill(Color(NSColor.controlBackgroundColor))
+                                )
                             }
 
                             Spacer()

--- a/Sources/ClaudeUsageMonitor/Views/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/ContentView.swift
@@ -225,82 +225,117 @@ struct ContentView: View {
                 // HistoryViewの中身を直接構築（ScrollViewを除外）
                 contentToCapture = AnyView(
                     VStack(spacing: 12) {
-                        // 月選択ヘッダーと月間サマリーを横並び
-                        HStack(spacing: 12) {
-                            // 月選択部分
-                            HStack(spacing: 8) {
+                        // 月選択ヘッダー
+                        HStack {
+                            Button(action: {}) {
                                 Image(systemName: "chevron.left")
-                                    .font(.system(size: 12, weight: .medium))
+                                    .font(.system(size: 14, weight: .medium))
                                     .foregroundStyle(.secondary)
-                                    .opacity(0.5)
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(true)
 
-                                Text(historyViewModel.monthDescription)
-                                    .font(.system(size: 14, weight: .semibold))
-                                    .frame(minWidth: 100)
+                            Text(historyViewModel.monthDescription)
+                                .font(.system(size: 16, weight: .semibold))
+                                .frame(minWidth: 140)
 
+                            Button(action: {}) {
                                 Image(systemName: "chevron.right")
-                                    .font(.system(size: 12, weight: .medium))
+                                    .font(.system(size: 14, weight: .medium))
                                     .foregroundStyle(.secondary)
-                                    .opacity(0.5)
                             }
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 6)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(Color(NSColor.controlBackgroundColor))
-                            )
-
-                            // 月間サマリー（インライン）
-                            if !historyViewModel.dailyData.isEmpty, let totals = historyViewModel.monthlyTotals {
-                                HStack(spacing: 16) {
-                                    // 合計
-                                    VStack(alignment: .leading, spacing: 4) {
-                                        HStack(spacing: 4) {
-                                            Image(systemName: "dollarsign.circle.fill")
-                                                .font(.system(size: 12))
-                                                .foregroundStyle(.secondary)
-                                            Text(L10n.History.total)
-                                                .font(.system(size: 11, weight: .medium))
-                                                .foregroundStyle(.secondary)
-                                        }
-                                        Text(String(format: "$%.0f", totals.totalCost))
-                                            .font(.system(size: 16, weight: .semibold, design: .rounded))
-                                        Text("\(NumberFormatters.formatTokens(totals.totalTokens))")
-                                            .font(.system(size: 12))
-                                            .foregroundStyle(.secondary)
-                                    }
-                                    
-                                    Divider()
-                                        .frame(height: 36)
-                                    
-                                    // 日次平均
-                                    VStack(alignment: .leading, spacing: 4) {
-                                        HStack(spacing: 4) {
-                                            Image(systemName: "calendar.day.timeline.left")
-                                                .font(.system(size: 12))
-                                                .foregroundStyle(.secondary)
-                                            Text(L10n.History.dailyAverage)
-                                                .font(.system(size: 11, weight: .medium))
-                                                .foregroundStyle(.secondary)
-                                        }
-                                        Text(String(format: "$%.0f", totals.totalCost / Double(historyViewModel.dailyData.count)))
-                                            .font(.system(size: 16, weight: .semibold, design: .rounded))
-                                        Text(L10n.History.perDay)
-                                            .font(.system(size: 12))
-                                            .foregroundStyle(.secondary)
-                                    }
-                                }
-                                .padding(.horizontal, 16)
-                                .padding(.vertical, 10)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 10)
-                                        .fill(Color(NSColor.controlBackgroundColor))
-                                )
-                            }
+                            .buttonStyle(.plain)
+                            .disabled(true)
 
                             Spacer()
                         }
                         .padding(.horizontal, 4)
+                        
+                        // 月間サマリー（カラフルなカード）
+                        if !historyViewModel.dailyData.isEmpty, let totals = historyViewModel.monthlyTotals {
+                            HStack(spacing: 12) {
+                                // 合計
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .fill(Color.blue.opacity(0.15))
+                                        .frame(height: 100)
+                                    
+                                    VStack(spacing: 6) {
+                                        Image(systemName: "dollarsign.circle.fill")
+                                            .font(.system(size: 22))
+                                            .foregroundStyle(.blue)
+                                        
+                                        Text(L10n.History.total)
+                                            .font(.system(size: 11, weight: .medium))
+                                            .foregroundStyle(.secondary)
+                                        
+                                        Text(String(format: "$%.2f", totals.totalCost))
+                                            .font(.system(size: 20, weight: .bold, design: .rounded))
+                                            .foregroundStyle(.primary)
+                                        
+                                        Text("\(NumberFormatters.formatTokens(totals.totalTokens)) tokens")
+                                            .font(.system(size: 10))
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                                .frame(maxWidth: .infinity)
+                                
+                                // 日次平均
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .fill(Color.green.opacity(0.15))
+                                        .frame(height: 100)
+                                    
+                                    VStack(spacing: 6) {
+                                        Image(systemName: "chart.line.uptrend.xyaxis")
+                                            .font(.system(size: 22))
+                                            .foregroundStyle(.green)
+                                        
+                                        Text(L10n.History.dailyAverage)
+                                            .font(.system(size: 11, weight: .medium))
+                                            .foregroundStyle(.secondary)
+                                        
+                                        Text(String(format: "$%.2f", totals.totalCost / Double(historyViewModel.dailyData.count)))
+                                            .font(.system(size: 20, weight: .bold, design: .rounded))
+                                            .foregroundStyle(.primary)
+                                        
+                                        Text(L10n.History.perDay)
+                                            .font(.system(size: 10))
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                                .frame(maxWidth: .infinity)
+                                
+                                // ピーク
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .fill(Color.orange.opacity(0.15))
+                                        .frame(height: 100)
+                                    
+                                    VStack(spacing: 6) {
+                                        Image(systemName: "flame.fill")
+                                            .font(.system(size: 22))
+                                            .foregroundStyle(.orange)
+                                        
+                                        Text(L10n.History.peak)
+                                            .font(.system(size: 11, weight: .medium))
+                                            .foregroundStyle(.secondary)
+                                        
+                                        if let peak = historyViewModel.dailyData.max(by: { $0.totalCost < $1.totalCost }) {
+                                            Text(String(format: "$%.2f", peak.totalCost))
+                                                .font(.system(size: 20, weight: .bold, design: .rounded))
+                                                .foregroundStyle(.primary)
+                                            
+                                            Text(formatShareDate(peak.date))
+                                                .font(.system(size: 10))
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    }
+                                }
+                                .frame(maxWidth: .infinity)
+                            }
+                            .padding(.horizontal, 4)
+                        }
 
                         // コンテンツ部分
                         VStack(spacing: 8) {

--- a/Sources/ClaudeUsageMonitor/Views/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/ContentView.swift
@@ -260,21 +260,21 @@ struct ContentView: View {
                                         .fill(Color.blue.opacity(0.15))
                                         .frame(height: 100)
                                     
-                                    VStack(spacing: 6) {
+                                    VStack(spacing: 4) {
                                         Image(systemName: "dollarsign.circle.fill")
-                                            .font(.system(size: 22))
+                                            .font(.system(size: 20))
                                             .foregroundStyle(.blue)
                                         
                                         Text(L10n.History.total)
-                                            .font(.system(size: 11, weight: .medium))
+                                            .font(.system(size: 10, weight: .medium))
                                             .foregroundStyle(.secondary)
                                         
                                         Text(String(format: "$%.2f", totals.totalCost))
-                                            .font(.system(size: 20, weight: .bold, design: .rounded))
+                                            .font(.system(size: 16, weight: .semibold, design: .rounded))
                                             .foregroundStyle(.primary)
                                         
-                                        Text("\(NumberFormatters.formatTokens(totals.totalTokens)) tokens")
-                                            .font(.system(size: 10))
+                                        Text(NumberFormatters.formatTokens(totals.totalTokens))
+                                            .font(.system(size: 9))
                                             .foregroundStyle(.secondary)
                                     }
                                 }
@@ -286,21 +286,21 @@ struct ContentView: View {
                                         .fill(Color.green.opacity(0.15))
                                         .frame(height: 100)
                                     
-                                    VStack(spacing: 6) {
+                                    VStack(spacing: 4) {
                                         Image(systemName: "chart.line.uptrend.xyaxis")
-                                            .font(.system(size: 22))
+                                            .font(.system(size: 20))
                                             .foregroundStyle(.green)
                                         
                                         Text(L10n.History.dailyAverage)
-                                            .font(.system(size: 11, weight: .medium))
+                                            .font(.system(size: 10, weight: .medium))
                                             .foregroundStyle(.secondary)
                                         
                                         Text(String(format: "$%.2f", totals.totalCost / Double(historyViewModel.dailyData.count)))
-                                            .font(.system(size: 20, weight: .bold, design: .rounded))
+                                            .font(.system(size: 16, weight: .semibold, design: .rounded))
                                             .foregroundStyle(.primary)
                                         
                                         Text(L10n.History.perDay)
-                                            .font(.system(size: 10))
+                                            .font(.system(size: 9))
                                             .foregroundStyle(.secondary)
                                     }
                                 }
@@ -312,22 +312,22 @@ struct ContentView: View {
                                         .fill(Color.orange.opacity(0.15))
                                         .frame(height: 100)
                                     
-                                    VStack(spacing: 6) {
+                                    VStack(spacing: 4) {
                                         Image(systemName: "flame.fill")
-                                            .font(.system(size: 22))
+                                            .font(.system(size: 20))
                                             .foregroundStyle(.orange)
                                         
                                         Text(L10n.History.peak)
-                                            .font(.system(size: 11, weight: .medium))
+                                            .font(.system(size: 10, weight: .medium))
                                             .foregroundStyle(.secondary)
                                         
                                         if let peak = historyViewModel.dailyData.max(by: { $0.totalCost < $1.totalCost }) {
                                             Text(String(format: "$%.2f", peak.totalCost))
-                                                .font(.system(size: 20, weight: .bold, design: .rounded))
+                                                .font(.system(size: 16, weight: .semibold, design: .rounded))
                                                 .foregroundStyle(.primary)
                                             
                                             Text(formatShareDate(peak.date))
-                                                .font(.system(size: 10))
+                                                .font(.system(size: 9))
                                                 .foregroundStyle(.secondary)
                                         }
                                     }

--- a/Sources/ClaudeUsageMonitor/Views/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/ContentView.swift
@@ -224,36 +224,75 @@ struct ContentView: View {
 
                 // HistoryViewの中身を直接構築（ScrollViewを除外）
                 contentToCapture = AnyView(
-                    VStack(spacing: 16) {
-                        // 月選択ヘッダー
-                        HStack {
-                            Image(systemName: "chevron.left")
-                                .font(.system(size: 14, weight: .medium))
-                                .foregroundStyle(.secondary)
-                                .opacity(0.5)
+                    VStack(spacing: 12) {
+                        // 月選択ヘッダーと月間サマリーを横並び
+                        HStack(spacing: 12) {
+                            // 月選択部分
+                            HStack(spacing: 8) {
+                                Image(systemName: "chevron.left")
+                                    .font(.system(size: 12, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                                    .opacity(0.5)
 
-                            Text(historyViewModel.monthDescription)
-                                .font(.system(size: 16, weight: .semibold))
-                                .frame(minWidth: 140)
+                                Text(historyViewModel.monthDescription)
+                                    .font(.system(size: 14, weight: .semibold))
+                                    .frame(minWidth: 100)
 
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 14, weight: .medium))
-                                .foregroundStyle(.secondary)
-                                .opacity(0.5)
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 12, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                                    .opacity(0.5)
+                            }
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 6)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color(NSColor.controlBackgroundColor))
+                            )
+
+                            // 月間サマリー（インライン）
+                            if !historyViewModel.dailyData.isEmpty, let totals = historyViewModel.monthlyTotals {
+                                HStack(spacing: 16) {
+                                    // 合計
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(L10n.History.total)
+                                            .font(.system(size: 10))
+                                            .foregroundStyle(.secondary)
+                                        HStack(spacing: 4) {
+                                            Text(String(format: "$%.0f", totals.totalCost))
+                                                .font(.system(size: 14, weight: .semibold))
+                                            Text("\(NumberFormatters.formatTokens(totals.totalTokens))")
+                                                .font(.system(size: 11))
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    }
+                                    
+                                    Divider()
+                                        .frame(height: 24)
+                                    
+                                    // 日次平均
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(L10n.History.dailyAverage)
+                                            .font(.system(size: 10))
+                                            .foregroundStyle(.secondary)
+                                        Text(String(format: "$%.0f", totals.totalCost / Double(historyViewModel.dailyData.count)))
+                                            .font(.system(size: 14, weight: .medium))
+                                    }
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .fill(Color(NSColor.controlBackgroundColor))
+                                )
+                            }
 
                             Spacer()
                         }
                         .padding(.horizontal, 4)
 
                         // コンテンツ部分
-                        VStack(spacing: 12) {
-                            if !historyViewModel.dailyData.isEmpty, let totals = historyViewModel.monthlyTotals {
-                                MonthlySummaryCard(
-                                    totals: totals,
-                                    dailyData: historyViewModel.dailyData
-                                )
-                            }
-
+                        VStack(spacing: 8) {
                             if historyViewModel.dailyData.isEmpty {
                                 EmptyStateView(
                                     message: L10n.History.noData
@@ -261,7 +300,7 @@ struct ContentView: View {
                                 .padding(.vertical, 60)
                             } else {
                                 ForEach(historyViewModel.dailyData.sorted(by: { $0.date > $1.date }), id: \.date) { daily in
-                                    DailyUsageCard(
+                                    CompactDailyUsageCard(
                                         daily: daily,
                                         isToday: isToday(daily.date)
                                     )

--- a/Sources/ClaudeUsageMonitor/Views/ContentView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/ContentView.swift
@@ -252,39 +252,70 @@ struct ContentView: View {
 
                             // 月間サマリー（インライン）
                             if !historyViewModel.dailyData.isEmpty, let totals = historyViewModel.monthlyTotals {
-                                HStack(spacing: 16) {
+                                HStack(spacing: 4) {
                                     // 合計
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text(L10n.History.total)
-                                            .font(.system(size: 10))
-                                            .foregroundStyle(.secondary)
-                                        HStack(spacing: 4) {
+                                    HStack(spacing: 12) {
+                                        VStack(spacing: 4) {
+                                            Image(systemName: "chart.bar.fill")
+                                                .font(.system(size: 16))
+                                                .foregroundStyle(.blue)
+                                                .frame(width: 20, height: 20)
+                                            
+                                            Text(L10n.History.total)
+                                                .font(.system(size: 9, weight: .medium))
+                                                .foregroundStyle(.secondary)
+                                        }
+                                        
+                                        VStack(alignment: .leading, spacing: 2) {
                                             Text(String(format: "$%.0f", totals.totalCost))
-                                                .font(.system(size: 14, weight: .semibold))
+                                                .font(.system(size: 16, weight: .semibold, design: .rounded))
+                                                .foregroundStyle(.primary)
                                             Text("\(NumberFormatters.formatTokens(totals.totalTokens))")
-                                                .font(.system(size: 11))
+                                                .font(.system(size: 11, weight: .medium))
                                                 .foregroundStyle(.secondary)
                                         }
                                     }
-                                    
-                                    Divider()
-                                        .frame(height: 24)
+                                    .padding(.horizontal, 16)
+                                    .padding(.vertical, 10)
+                                    .frame(maxWidth: .infinity)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 10)
+                                            .fill(Color(NSColor.controlBackgroundColor))
+                                            .opacity(0.8)
+                                    )
                                     
                                     // 日次平均
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text(L10n.History.dailyAverage)
-                                            .font(.system(size: 10))
-                                            .foregroundStyle(.secondary)
-                                        Text(String(format: "$%.0f", totals.totalCost / Double(historyViewModel.dailyData.count)))
-                                            .font(.system(size: 14, weight: .medium))
+                                    HStack(spacing: 12) {
+                                        VStack(spacing: 4) {
+                                            Image(systemName: "calendar.day.timeline.left")
+                                                .font(.system(size: 16))
+                                                .foregroundStyle(.green)
+                                                .frame(width: 20, height: 20)
+                                            
+                                            Text(L10n.History.dailyAverage)
+                                                .font(.system(size: 9, weight: .medium))
+                                                .foregroundStyle(.secondary)
+                                        }
+                                        
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text(String(format: "$%.0f", totals.totalCost / Double(historyViewModel.dailyData.count)))
+                                                .font(.system(size: 16, weight: .semibold, design: .rounded))
+                                                .foregroundStyle(.primary)
+                                            Text(L10n.History.perDay)
+                                                .font(.system(size: 11, weight: .medium))
+                                                .foregroundStyle(.secondary)
+                                        }
                                     }
+                                    .padding(.horizontal, 16)
+                                    .padding(.vertical, 10)
+                                    .frame(maxWidth: .infinity)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 10)
+                                            .fill(Color(NSColor.controlBackgroundColor))
+                                            .opacity(0.8)
+                                    )
                                 }
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 6)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .fill(Color(NSColor.controlBackgroundColor))
-                                )
+                                .padding(.horizontal, 2)
                             }
 
                             Spacer()

--- a/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
@@ -281,15 +281,15 @@ struct CompactDailyUsageCard: View {
     var body: some View {
         HStack(spacing: 0) {
             // 日付部分（コンパクト化）
-            HStack(spacing: 6) {
+            HStack(spacing: 4) {
                 Text(dayString)
                     .font(.system(size: 16, weight: .semibold, design: .rounded))
                     .frame(width: 24, alignment: .trailing)
 
                 Text(weekdayString)
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.secondary)
-                    .frame(width: 16)
+                    .frame(width: 28)
             }
             .padding(.leading, 8)
 

--- a/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
@@ -61,68 +61,95 @@ struct HistoryView: View {
             
             // 月間サマリー（常時表示）
             if !viewModel.isLoading && !viewModel.dailyData.isEmpty, let totals = viewModel.monthlyTotals {
-                HStack(spacing: 0) {
+                HStack(spacing: 12) {
                     // 合計
-                    VStack(spacing: 6) {
-                        Text(L10n.History.total)
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.secondary)
+                    VStack(spacing: 8) {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.blue.opacity(0.15))
+                                .frame(height: 80)
+                            
+                            VStack(spacing: 4) {
+                                Image(systemName: "dollarsign.circle.fill")
+                                    .font(.system(size: 20))
+                                    .foregroundStyle(.blue)
+                                
+                                Text(L10n.History.total)
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                                
+                                Text(String(format: "$%.2f", totals.totalCost))
+                                    .font(.system(size: 18, weight: .bold, design: .rounded))
+                                    .foregroundStyle(.primary)
+                            }
+                        }
                         
-                        Text(String(format: "$%.2f", totals.totalCost))
-                            .font(.system(size: 18, weight: .semibold, design: .rounded))
-                        
-                        Text("\(NumberFormatters.formatTokens(totals.totalTokens))")
-                            .font(.system(size: 11))
+                        Text("\(NumberFormatters.formatTokens(totals.totalTokens)) tokens")
+                            .font(.system(size: 10))
                             .foregroundStyle(.secondary)
                     }
                     .frame(maxWidth: .infinity)
-                    
-                    Divider()
-                        .frame(height: 50)
-                        .padding(.horizontal, 8)
                     
                     // 日次平均
-                    VStack(spacing: 6) {
-                        Text(L10n.History.dailyAverage)
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.secondary)
-                        
-                        Text(String(format: "$%.2f", totals.totalCost / Double(viewModel.dailyData.count)))
-                            .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    VStack(spacing: 8) {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.green.opacity(0.15))
+                                .frame(height: 80)
+                            
+                            VStack(spacing: 4) {
+                                Image(systemName: "chart.line.uptrend.xyaxis")
+                                    .font(.system(size: 20))
+                                    .foregroundStyle(.green)
+                                
+                                Text(L10n.History.dailyAverage)
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                                
+                                Text(String(format: "$%.2f", totals.totalCost / Double(viewModel.dailyData.count)))
+                                    .font(.system(size: 18, weight: .bold, design: .rounded))
+                                    .foregroundStyle(.primary)
+                            }
+                        }
                         
                         Text(L10n.History.perDay)
-                            .font(.system(size: 11))
+                            .font(.system(size: 10))
                             .foregroundStyle(.secondary)
                     }
                     .frame(maxWidth: .infinity)
                     
-                    Divider()
-                        .frame(height: 50)
-                        .padding(.horizontal, 8)
-                    
                     // ピーク
-                    VStack(spacing: 6) {
-                        Text(L10n.History.peak)
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.secondary)
+                    VStack(spacing: 8) {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.orange.opacity(0.15))
+                                .frame(height: 80)
+                            
+                            VStack(spacing: 4) {
+                                Image(systemName: "flame.fill")
+                                    .font(.system(size: 20))
+                                    .foregroundStyle(.orange)
+                                
+                                Text(L10n.History.peak)
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                                
+                                if let peak = viewModel.dailyData.max(by: { $0.totalCost < $1.totalCost }) {
+                                    Text(String(format: "$%.2f", peak.totalCost))
+                                        .font(.system(size: 18, weight: .bold, design: .rounded))
+                                        .foregroundStyle(.primary)
+                                }
+                            }
+                        }
                         
                         if let peak = viewModel.dailyData.max(by: { $0.totalCost < $1.totalCost }) {
-                            Text(String(format: "$%.2f", peak.totalCost))
-                                .font(.system(size: 18, weight: .semibold, design: .rounded))
-                            
                             Text(self.formatPeakDate(peak.date))
-                                .font(.system(size: 11))
+                                .font(.system(size: 10))
                                 .foregroundStyle(.secondary)
                         }
                     }
                     .frame(maxWidth: .infinity)
                 }
-                .padding(.vertical, 12)
-                .padding(.horizontal, 12)
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(Color(NSColor.controlBackgroundColor))
-                )
                 .padding(.horizontal, 4)
             }
 

--- a/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
@@ -47,39 +47,70 @@ struct HistoryView: View {
 
                 // 月間サマリー（インライン）
                 if !viewModel.isLoading && !viewModel.dailyData.isEmpty, let totals = viewModel.monthlyTotals {
-                    HStack(spacing: 16) {
+                    HStack(spacing: 4) {
                         // 合計
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(L10n.History.total)
-                                .font(.system(size: 10))
-                                .foregroundStyle(.secondary)
-                            HStack(spacing: 4) {
+                        HStack(spacing: 12) {
+                            VStack(spacing: 4) {
+                                Image(systemName: "chart.bar.fill")
+                                    .font(.system(size: 16))
+                                    .foregroundStyle(.blue)
+                                    .frame(width: 20, height: 20)
+                                
+                                Text(L10n.History.total)
+                                    .font(.system(size: 9, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                            }
+                            
+                            VStack(alignment: .leading, spacing: 2) {
                                 Text(String(format: "$%.0f", totals.totalCost))
-                                    .font(.system(size: 14, weight: .semibold))
+                                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                                    .foregroundStyle(.primary)
                                 Text("\(NumberFormatters.formatTokens(totals.totalTokens))")
-                                    .font(.system(size: 11))
+                                    .font(.system(size: 11, weight: .medium))
                                     .foregroundStyle(.secondary)
                             }
                         }
-                        
-                        Divider()
-                            .frame(height: 24)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .frame(maxWidth: .infinity)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color(NSColor.controlBackgroundColor))
+                                .opacity(0.8)
+                        )
                         
                         // 日次平均
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(L10n.History.dailyAverage)
-                                .font(.system(size: 10))
-                                .foregroundStyle(.secondary)
-                            Text(String(format: "$%.0f", totals.totalCost / Double(viewModel.dailyData.count)))
-                                .font(.system(size: 14, weight: .medium))
+                        HStack(spacing: 12) {
+                            VStack(spacing: 4) {
+                                Image(systemName: "calendar.day.timeline.left")
+                                    .font(.system(size: 16))
+                                    .foregroundStyle(.green)
+                                    .frame(width: 20, height: 20)
+                                
+                                Text(L10n.History.dailyAverage)
+                                    .font(.system(size: 9, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                            }
+                            
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(String(format: "$%.0f", totals.totalCost / Double(viewModel.dailyData.count)))
+                                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                                    .foregroundStyle(.primary)
+                                Text(L10n.History.perDay)
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                            }
                         }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .frame(maxWidth: .infinity)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color(NSColor.controlBackgroundColor))
+                                .opacity(0.8)
+                        )
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(Color(NSColor.controlBackgroundColor))
-                    )
+                    .padding(.horizontal, 2)
                 }
 
                 Spacer()

--- a/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
@@ -63,89 +63,81 @@ struct HistoryView: View {
             if !viewModel.isLoading && !viewModel.dailyData.isEmpty, let totals = viewModel.monthlyTotals {
                 HStack(spacing: 12) {
                     // 合計
-                    VStack(spacing: 8) {
-                        ZStack {
-                            RoundedRectangle(cornerRadius: 12)
-                                .fill(Color.blue.opacity(0.15))
-                                .frame(height: 80)
-                            
-                            VStack(spacing: 4) {
-                                Image(systemName: "dollarsign.circle.fill")
-                                    .font(.system(size: 20))
-                                    .foregroundStyle(.blue)
-                                
-                                Text(L10n.History.total)
-                                    .font(.system(size: 11, weight: .medium))
-                                    .foregroundStyle(.secondary)
-                                
-                                Text(String(format: "$%.2f", totals.totalCost))
-                                    .font(.system(size: 18, weight: .bold, design: .rounded))
-                                    .foregroundStyle(.primary)
-                            }
-                        }
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color.blue.opacity(0.15))
+                            .frame(height: 100)
                         
-                        Text("\(NumberFormatters.formatTokens(totals.totalTokens)) tokens")
-                            .font(.system(size: 10))
-                            .foregroundStyle(.secondary)
+                        VStack(spacing: 6) {
+                            Image(systemName: "dollarsign.circle.fill")
+                                .font(.system(size: 22))
+                                .foregroundStyle(.blue)
+                            
+                            Text(L10n.History.total)
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.secondary)
+                            
+                            Text(String(format: "$%.2f", totals.totalCost))
+                                .font(.system(size: 20, weight: .bold, design: .rounded))
+                                .foregroundStyle(.primary)
+                            
+                            Text("\(NumberFormatters.formatTokens(totals.totalTokens)) tokens")
+                                .font(.system(size: 10))
+                                .foregroundStyle(.secondary)
+                        }
                     }
                     .frame(maxWidth: .infinity)
                     
                     // 日次平均
-                    VStack(spacing: 8) {
-                        ZStack {
-                            RoundedRectangle(cornerRadius: 12)
-                                .fill(Color.green.opacity(0.15))
-                                .frame(height: 80)
-                            
-                            VStack(spacing: 4) {
-                                Image(systemName: "chart.line.uptrend.xyaxis")
-                                    .font(.system(size: 20))
-                                    .foregroundStyle(.green)
-                                
-                                Text(L10n.History.dailyAverage)
-                                    .font(.system(size: 11, weight: .medium))
-                                    .foregroundStyle(.secondary)
-                                
-                                Text(String(format: "$%.2f", totals.totalCost / Double(viewModel.dailyData.count)))
-                                    .font(.system(size: 18, weight: .bold, design: .rounded))
-                                    .foregroundStyle(.primary)
-                            }
-                        }
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color.green.opacity(0.15))
+                            .frame(height: 100)
                         
-                        Text(L10n.History.perDay)
-                            .font(.system(size: 10))
-                            .foregroundStyle(.secondary)
+                        VStack(spacing: 6) {
+                            Image(systemName: "chart.line.uptrend.xyaxis")
+                                .font(.system(size: 22))
+                                .foregroundStyle(.green)
+                            
+                            Text(L10n.History.dailyAverage)
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.secondary)
+                            
+                            Text(String(format: "$%.2f", totals.totalCost / Double(viewModel.dailyData.count)))
+                                .font(.system(size: 20, weight: .bold, design: .rounded))
+                                .foregroundStyle(.primary)
+                            
+                            Text(L10n.History.perDay)
+                                .font(.system(size: 10))
+                                .foregroundStyle(.secondary)
+                        }
                     }
                     .frame(maxWidth: .infinity)
                     
                     // ピーク
-                    VStack(spacing: 8) {
-                        ZStack {
-                            RoundedRectangle(cornerRadius: 12)
-                                .fill(Color.orange.opacity(0.15))
-                                .frame(height: 80)
-                            
-                            VStack(spacing: 4) {
-                                Image(systemName: "flame.fill")
-                                    .font(.system(size: 20))
-                                    .foregroundStyle(.orange)
-                                
-                                Text(L10n.History.peak)
-                                    .font(.system(size: 11, weight: .medium))
-                                    .foregroundStyle(.secondary)
-                                
-                                if let peak = viewModel.dailyData.max(by: { $0.totalCost < $1.totalCost }) {
-                                    Text(String(format: "$%.2f", peak.totalCost))
-                                        .font(.system(size: 18, weight: .bold, design: .rounded))
-                                        .foregroundStyle(.primary)
-                                }
-                            }
-                        }
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color.orange.opacity(0.15))
+                            .frame(height: 100)
                         
-                        if let peak = viewModel.dailyData.max(by: { $0.totalCost < $1.totalCost }) {
-                            Text(self.formatPeakDate(peak.date))
-                                .font(.system(size: 10))
+                        VStack(spacing: 6) {
+                            Image(systemName: "flame.fill")
+                                .font(.system(size: 22))
+                                .foregroundStyle(.orange)
+                            
+                            Text(L10n.History.peak)
+                                .font(.system(size: 11, weight: .medium))
                                 .foregroundStyle(.secondary)
+                            
+                            if let peak = viewModel.dailyData.max(by: { $0.totalCost < $1.totalCost }) {
+                                Text(String(format: "$%.2f", peak.totalCost))
+                                    .font(.system(size: 20, weight: .bold, design: .rounded))
+                                    .foregroundStyle(.primary)
+                                
+                                Text(self.formatPeakDate(peak.date))
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(.secondary)
+                            }
                         }
                     }
                     .frame(maxWidth: .infinity)

--- a/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
@@ -4,94 +4,53 @@ struct HistoryView: View {
     @StateObject var viewModel: HistoryViewModel
     @Environment(\.colorScheme) var colorScheme
 
+    @State private var selectedSummaryTab = 0
+    
+    // formatPeakDate関数を定義
+    private func formatPeakDate(_ dateString: String) -> String {
+        let inputFormatter = DateFormatter()
+        inputFormatter.dateFormat = "yyyy-MM-dd"
+
+        let outputFormatter = DateFormatter()
+        outputFormatter.dateFormat = "M/d"
+
+        if let date = inputFormatter.date(from: dateString) {
+            return outputFormatter.string(from: date)
+        }
+        return dateString
+    }
+    
     var body: some View {
         VStack(spacing: 12) {
-            // 月選択ヘッダーと月間サマリーを横並び
-            HStack(spacing: 12) {
-                // 月選択部分
-                HStack(spacing: 8) {
-                    Button(action: {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            viewModel.previousMonth()
-                        }
-                    }) {
-                        Image(systemName: "chevron.left")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(.secondary)
+            // 月選択ヘッダー
+            HStack {
+                Button(action: {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        viewModel.previousMonth()
                     }
-                    .buttonStyle(.plain)
-                    .disabled(isFirstAvailableMonth)
-
-                    Text(viewModel.monthDescription)
-                        .font(.system(size: 14, weight: .semibold))
-                        .frame(minWidth: 100)
-
-                    Button(action: {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            viewModel.nextMonth()
-                        }
-                    }) {
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(isCurrentMonth)
+                }) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.secondary)
                 }
-                .padding(.horizontal, 8)
-                .padding(.vertical, 6)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(Color(NSColor.controlBackgroundColor))
-                )
+                .buttonStyle(.plain)
+                .disabled(isFirstAvailableMonth)
 
-                // 月間サマリー（インライン）
-                if !viewModel.isLoading && !viewModel.dailyData.isEmpty, let totals = viewModel.monthlyTotals {
-                    HStack(spacing: 16) {
-                        // 合計
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack(spacing: 4) {
-                                Image(systemName: "dollarsign.circle.fill")
-                                    .font(.system(size: 12))
-                                    .foregroundStyle(.secondary)
-                                Text(L10n.History.total)
-                                    .font(.system(size: 11, weight: .medium))
-                                    .foregroundStyle(.secondary)
-                            }
-                            Text(String(format: "$%.0f", totals.totalCost))
-                                .font(.system(size: 16, weight: .semibold, design: .rounded))
-                            Text("\(NumberFormatters.formatTokens(totals.totalTokens))")
-                                .font(.system(size: 12))
-                                .foregroundStyle(.secondary)
-                        }
-                        
-                        Divider()
-                            .frame(height: 36)
-                        
-                        // 日次平均
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack(spacing: 4) {
-                                Image(systemName: "calendar.day.timeline.left")
-                                    .font(.system(size: 12))
-                                    .foregroundStyle(.secondary)
-                                Text(L10n.History.dailyAverage)
-                                    .font(.system(size: 11, weight: .medium))
-                                    .foregroundStyle(.secondary)
-                            }
-                            Text(String(format: "$%.0f", totals.totalCost / Double(viewModel.dailyData.count)))
-                                .font(.system(size: 16, weight: .semibold, design: .rounded))
-                            Text(L10n.History.perDay)
-                                .font(.system(size: 12))
-                                .foregroundStyle(.secondary)
-                        }
+                Text(viewModel.monthDescription)
+                    .font(.system(size: 16, weight: .semibold))
+                    .frame(minWidth: 140)
+
+                Button(action: {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        viewModel.nextMonth()
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(Color(NSColor.controlBackgroundColor))
-                    )
+                }) {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.secondary)
                 }
+                .buttonStyle(.plain)
+                .disabled(isCurrentMonth)
 
                 Spacer()
 
@@ -101,6 +60,78 @@ struct HistoryView: View {
                 }
             }
             .padding(.horizontal, 4)
+            
+            // 月間サマリー（タブ形式）
+            if !viewModel.isLoading && !viewModel.dailyData.isEmpty, let totals = viewModel.monthlyTotals {
+                VStack(spacing: 0) {
+                    // タブセレクター
+                    HStack(spacing: 0) {
+                        ForEach(0..<3) { index in
+                            Button(action: {
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    selectedSummaryTab = index
+                                }
+                            }) {
+                                VStack(spacing: 4) {
+                                    Text(index == 0 ? L10n.History.total : (index == 1 ? L10n.History.dailyAverage : L10n.History.peak))
+                                        .font(.system(size: 12, weight: selectedSummaryTab == index ? .semibold : .regular))
+                                        .foregroundStyle(selectedSummaryTab == index ? .primary : .secondary)
+                                    
+                                    Rectangle()
+                                        .fill(selectedSummaryTab == index ? Color.accentColor : Color.clear)
+                                        .frame(height: 2)
+                                }
+                                .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.horizontal, 4)
+                    
+                    // コンテンツ
+                    Group {
+                        switch selectedSummaryTab {
+                        case 0: // 合計
+                            VStack(spacing: 8) {
+                                Text(String(format: "$%.2f", totals.totalCost))
+                                    .font(.system(size: 24, weight: .semibold, design: .rounded))
+                                Text("\(NumberFormatters.formatTokens(totals.totalTokens)) tokens")
+                                    .font(.system(size: 14))
+                                    .foregroundStyle(.secondary)
+                            }
+                        case 1: // 日次平均
+                            VStack(spacing: 8) {
+                                Text(String(format: "$%.2f", totals.totalCost / Double(viewModel.dailyData.count)))
+                                    .font(.system(size: 24, weight: .semibold, design: .rounded))
+                                Text(L10n.History.perDay)
+                                    .font(.system(size: 14))
+                                    .foregroundStyle(.secondary)
+                            }
+                        case 2: // ピーク
+                            if let peak = viewModel.dailyData.max(by: { $0.totalCost < $1.totalCost }) {
+                                VStack(spacing: 8) {
+                                    Text(String(format: "$%.2f", peak.totalCost))
+                                        .font(.system(size: 24, weight: .semibold, design: .rounded))
+                                    Text(self.formatPeakDate(peak.date))
+                                        .font(.system(size: 14))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        default:
+                            EmptyView()
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .padding(.horizontal, 16)
+                    .animation(.easeInOut(duration: 0.2), value: selectedSummaryTab)
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color(NSColor.controlBackgroundColor))
+                )
+                .padding(.horizontal, 4)
+            }
 
             ScrollView {
                 VStack(spacing: 8) {
@@ -173,6 +204,19 @@ struct MonthlySummaryCard: View {
     private var peakDay: DailyUsage? {
         dailyData.max(by: { $0.totalCost < $1.totalCost })
     }
+    
+    private func formatPeakDate(_ dateString: String) -> String {
+        let inputFormatter = DateFormatter()
+        inputFormatter.dateFormat = "yyyy-MM-dd"
+
+        let outputFormatter = DateFormatter()
+        outputFormatter.dateFormat = "M/d"
+
+        if let date = inputFormatter.date(from: dateString) {
+            return outputFormatter.string(from: date)
+        }
+        return dateString
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -243,19 +287,6 @@ struct MonthlySummaryCard: View {
                     .fill(Color(NSColor.controlBackgroundColor))
             )
         }
-    }
-
-    private func formatPeakDate(_ dateString: String) -> String {
-        let inputFormatter = DateFormatter()
-        inputFormatter.dateFormat = "yyyy-MM-dd"
-
-        let outputFormatter = DateFormatter()
-        outputFormatter.dateFormat = "M/d"
-
-        if let date = inputFormatter.date(from: dateString) {
-            return outputFormatter.string(from: date)
-        }
-        return dateString
     }
 }
 

--- a/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
@@ -5,68 +5,100 @@ struct HistoryView: View {
     @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
-        VStack(spacing: 16) {
-            // 月選択ヘッダー
-            HStack {
-                Button(action: {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        viewModel.previousMonth()
+        VStack(spacing: 12) {
+            // 月選択ヘッダーと月間サマリーを横並び
+            HStack(spacing: 12) {
+                // 月選択部分
+                HStack(spacing: 8) {
+                    Button(action: {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            viewModel.previousMonth()
+                        }
+                    }) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.secondary)
                     }
-                }) {
-                    Image(systemName: "chevron.left")
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
-                .disabled(isFirstAvailableMonth)
+                    .buttonStyle(.plain)
+                    .disabled(isFirstAvailableMonth)
 
-                Text(viewModel.monthDescription)
-                    .font(.system(size: 16, weight: .semibold))
-                    .frame(minWidth: 140)
+                    Text(viewModel.monthDescription)
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(minWidth: 100)
 
-                Button(action: {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        viewModel.nextMonth()
+                    Button(action: {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            viewModel.nextMonth()
+                        }
+                    }) {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.secondary)
                     }
-                }) {
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(.secondary)
+                    .buttonStyle(.plain)
+                    .disabled(isCurrentMonth)
                 }
-                .buttonStyle(.plain)
-                .disabled(isCurrentMonth)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color(NSColor.controlBackgroundColor))
+                )
+
+                // 月間サマリー（インライン）
+                if !viewModel.isLoading && !viewModel.dailyData.isEmpty, let totals = viewModel.monthlyTotals {
+                    HStack(spacing: 16) {
+                        // 合計
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(L10n.History.total)
+                                .font(.system(size: 10))
+                                .foregroundStyle(.secondary)
+                            HStack(spacing: 4) {
+                                Text(String(format: "$%.0f", totals.totalCost))
+                                    .font(.system(size: 14, weight: .semibold))
+                                Text("\(NumberFormatters.formatTokens(totals.totalTokens))")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        
+                        Divider()
+                            .frame(height: 24)
+                        
+                        // 日次平均
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(L10n.History.dailyAverage)
+                                .font(.system(size: 10))
+                                .foregroundStyle(.secondary)
+                            Text(String(format: "$%.0f", totals.totalCost / Double(viewModel.dailyData.count)))
+                                .font(.system(size: 14, weight: .medium))
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color(NSColor.controlBackgroundColor))
+                    )
+                }
 
                 Spacer()
 
                 if viewModel.isLoading {
                     ProgressView()
-                        .scaleEffect(0.7)
+                        .scaleEffect(0.6)
                 }
             }
             .padding(.horizontal, 4)
 
             ScrollView {
-                VStack(spacing: 12) {
+                VStack(spacing: 8) {
                     if viewModel.isLoading {
                         // Skeleton loading state
-                        MonthlySummarySkeletonCard()
-
                         ForEach(0..<5) { _ in
                             DailyUsageSkeletonCard()
                         }
                     } else {
-                        // 月間サマリー
-                        if !viewModel.dailyData.isEmpty, let totals = viewModel.monthlyTotals {
-                            MonthlySummaryCard(
-                                totals: totals,
-                                dailyData: viewModel.dailyData
-                            )
-                                .transition(.asymmetric(
-                                    insertion: .opacity.combined(with: .move(edge: .top)),
-                                    removal: .opacity
-                                ))
-                        }
-
                         // 日次データ
                         if viewModel.dailyData.isEmpty {
                             EmptyStateView(
@@ -76,7 +108,7 @@ struct HistoryView: View {
                             .transition(.opacity)
                         } else {
                             ForEach(viewModel.dailyData.sorted(by: { $0.date > $1.date }), id: \.date) { daily in
-                                DailyUsageCard(
+                                CompactDailyUsageCard(
                                     daily: daily,
                                     isToday: isToday(daily.date)
                                 )
@@ -133,21 +165,26 @@ struct MonthlySummaryCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("月間サマリー")
+            Text(L10n.History.monthSummary)
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(.secondary)
 
             VStack(spacing: 10) {
                 // 合計
                 HStack {
-                    Label("合計", systemImage: "yensign.circle.fill")
+                    Label(L10n.History.total, systemImage: "dollarsign.circle.fill")
                         .font(.system(size: 14, weight: .medium))
                         .foregroundStyle(.primary)
 
                     Spacer()
 
-                    Text(String(format: "$%.2f", totals.totalCost))
-                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text(String(format: "$%.2f", totals.totalCost))
+                            .font(.system(size: 16, weight: .semibold, design: .rounded))
+                        Text("\(NumberFormatters.formatTokens(totals.totalTokens)) tokens")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
                 }
 
                 Divider()
@@ -155,7 +192,7 @@ struct MonthlySummaryCard: View {
 
                 // 日次平均
                 HStack {
-                    Label("日次平均", systemImage: "chart.bar.fill")
+                    Label(L10n.History.dailyAverage, systemImage: "chart.bar.fill")
                         .font(.system(size: 14, weight: .medium))
                         .foregroundStyle(.blue)
 
@@ -169,7 +206,7 @@ struct MonthlySummaryCard: View {
                 // ピーク日
                 if let peak = peakDay {
                     HStack {
-                        Label("ピーク", systemImage: "flame.fill")
+                        Label(L10n.History.peak, systemImage: "flame.fill")
                             .font(.system(size: 14, weight: .medium))
                             .foregroundStyle(.orange)
 
@@ -211,7 +248,105 @@ struct MonthlySummaryCard: View {
     }
 }
 
-// 日次使用量カード
+// コンパクトな日次使用量カード
+struct CompactDailyUsageCard: View {
+    let daily: DailyUsage
+    let isToday: Bool
+
+    private var date: Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.date(from: daily.date)
+    }
+
+    private var dayString: String {
+        guard let date = date else { return "" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "dd"
+        return formatter.string(from: date)
+    }
+
+    private var weekdayString: String {
+        guard let date = date else { return "" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "E"
+        formatter.locale = Locale(identifier: LanguageSettings.shared.effectiveLanguageCode() == "ja" ? "ja_JP" : "en_US")
+        return formatter.string(from: date)
+    }
+
+    private var totalTokens: Int {
+        daily.inputTokens + daily.outputTokens
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // 日付部分（コンパクト化）
+            HStack(spacing: 6) {
+                Text(dayString)
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .frame(width: 24, alignment: .trailing)
+
+                Text(weekdayString)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 16)
+            }
+            .padding(.leading, 8)
+
+            // コスト情報（コンパクト化）
+            HStack {
+                Text(String(format: "$%.2f", daily.totalCost))
+                    .font(.system(size: 14, weight: .semibold))
+
+                Text("\(NumberFormatters.formatTokens(totalTokens)) • \(formatModels(daily.modelsUsed))")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                if isToday {
+                    Text(L10n.History.today)
+                        .font(.system(size: 10, weight: .medium))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule()
+                                .fill(Color.blue)
+                        )
+                        .foregroundStyle(.white)
+                }
+            }
+            .padding(.horizontal, 12)
+            .frame(maxWidth: .infinity)
+        }
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(NSColor.controlBackgroundColor))
+                .opacity(isToday ? 1.0 : 0.6)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(isToday ? Color.blue.opacity(0.3) : Color.clear, lineWidth: 1)
+        )
+    }
+
+    private func formatModels(_ models: [String]) -> String {
+        let shortNames = models.map { model in
+            if model.contains("opus") {
+                return "Opus"
+            } else if model.contains("sonnet") {
+                return "Sonnet"
+            } else if model.contains("haiku") {
+                return "Haiku"
+            }
+            return "Other"
+        }
+        return shortNames.joined(separator: ", ")
+    }
+}
+
+// 日次使用量カード（元のバージョン）
 struct DailyUsageCard: View {
     let daily: DailyUsage
     let isToday: Bool
@@ -233,7 +368,7 @@ struct DailyUsageCard: View {
         guard let date = date else { return "" }
         let formatter = DateFormatter()
         formatter.dateFormat = "E"
-        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.locale = Locale(identifier: LanguageSettings.shared.effectiveLanguageCode() == "ja" ? "ja_JP" : "en_US")
         return formatter.string(from: date)
     }
 
@@ -269,7 +404,7 @@ struct DailyUsageCard: View {
                     Spacer()
 
                     if isToday {
-                        Text("今日")
+                        Text(L10n.History.today)
                             .font(.system(size: 11, weight: .medium))
                             .padding(.horizontal, 8)
                             .padding(.vertical, 3)

--- a/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
@@ -4,8 +4,6 @@ struct HistoryView: View {
     @StateObject var viewModel: HistoryViewModel
     @Environment(\.colorScheme) var colorScheme
 
-    @State private var selectedSummaryTab = 0
-    
     // formatPeakDate関数を定義
     private func formatPeakDate(_ dateString: String) -> String {
         let inputFormatter = DateFormatter()
@@ -61,71 +59,66 @@ struct HistoryView: View {
             }
             .padding(.horizontal, 4)
             
-            // 月間サマリー（タブ形式）
+            // 月間サマリー（常時表示）
             if !viewModel.isLoading && !viewModel.dailyData.isEmpty, let totals = viewModel.monthlyTotals {
-                VStack(spacing: 0) {
-                    // タブセレクター
-                    HStack(spacing: 0) {
-                        ForEach(0..<3) { index in
-                            Button(action: {
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    selectedSummaryTab = index
-                                }
-                            }) {
-                                VStack(spacing: 4) {
-                                    Text(index == 0 ? L10n.History.total : (index == 1 ? L10n.History.dailyAverage : L10n.History.peak))
-                                        .font(.system(size: 12, weight: selectedSummaryTab == index ? .semibold : .regular))
-                                        .foregroundStyle(selectedSummaryTab == index ? .primary : .secondary)
-                                    
-                                    Rectangle()
-                                        .fill(selectedSummaryTab == index ? Color.accentColor : Color.clear)
-                                        .frame(height: 2)
-                                }
-                                .frame(maxWidth: .infinity)
-                            }
-                            .buttonStyle(.plain)
-                        }
+                HStack(spacing: 0) {
+                    // 合計
+                    VStack(spacing: 6) {
+                        Text(L10n.History.total)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.secondary)
+                        
+                        Text(String(format: "$%.2f", totals.totalCost))
+                            .font(.system(size: 18, weight: .semibold, design: .rounded))
+                        
+                        Text("\(NumberFormatters.formatTokens(totals.totalTokens))")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
                     }
-                    .padding(.horizontal, 4)
+                    .frame(maxWidth: .infinity)
                     
-                    // コンテンツ
-                    Group {
-                        switch selectedSummaryTab {
-                        case 0: // 合計
-                            VStack(spacing: 8) {
-                                Text(String(format: "$%.2f", totals.totalCost))
-                                    .font(.system(size: 24, weight: .semibold, design: .rounded))
-                                Text("\(NumberFormatters.formatTokens(totals.totalTokens)) tokens")
-                                    .font(.system(size: 14))
-                                    .foregroundStyle(.secondary)
-                            }
-                        case 1: // 日次平均
-                            VStack(spacing: 8) {
-                                Text(String(format: "$%.2f", totals.totalCost / Double(viewModel.dailyData.count)))
-                                    .font(.system(size: 24, weight: .semibold, design: .rounded))
-                                Text(L10n.History.perDay)
-                                    .font(.system(size: 14))
-                                    .foregroundStyle(.secondary)
-                            }
-                        case 2: // ピーク
-                            if let peak = viewModel.dailyData.max(by: { $0.totalCost < $1.totalCost }) {
-                                VStack(spacing: 8) {
-                                    Text(String(format: "$%.2f", peak.totalCost))
-                                        .font(.system(size: 24, weight: .semibold, design: .rounded))
-                                    Text(self.formatPeakDate(peak.date))
-                                        .font(.system(size: 14))
-                                        .foregroundStyle(.secondary)
-                                }
-                            }
-                        default:
-                            EmptyView()
+                    Divider()
+                        .frame(height: 50)
+                        .padding(.horizontal, 8)
+                    
+                    // 日次平均
+                    VStack(spacing: 6) {
+                        Text(L10n.History.dailyAverage)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.secondary)
+                        
+                        Text(String(format: "$%.2f", totals.totalCost / Double(viewModel.dailyData.count)))
+                            .font(.system(size: 18, weight: .semibold, design: .rounded))
+                        
+                        Text(L10n.History.perDay)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    
+                    Divider()
+                        .frame(height: 50)
+                        .padding(.horizontal, 8)
+                    
+                    // ピーク
+                    VStack(spacing: 6) {
+                        Text(L10n.History.peak)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.secondary)
+                        
+                        if let peak = viewModel.dailyData.max(by: { $0.totalCost < $1.totalCost }) {
+                            Text(String(format: "$%.2f", peak.totalCost))
+                                .font(.system(size: 18, weight: .semibold, design: .rounded))
+                            
+                            Text(self.formatPeakDate(peak.date))
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
                         }
                     }
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
-                    .padding(.horizontal, 16)
-                    .animation(.easeInOut(duration: 0.2), value: selectedSummaryTab)
                 }
+                .padding(.vertical, 12)
+                .padding(.horizontal, 12)
                 .background(
                     RoundedRectangle(cornerRadius: 10)
                         .fill(Color(NSColor.controlBackgroundColor))

--- a/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
@@ -68,21 +68,21 @@ struct HistoryView: View {
                             .fill(Color.blue.opacity(0.15))
                             .frame(height: 100)
                         
-                        VStack(spacing: 6) {
+                        VStack(spacing: 4) {
                             Image(systemName: "dollarsign.circle.fill")
-                                .font(.system(size: 22))
+                                .font(.system(size: 20))
                                 .foregroundStyle(.blue)
                             
                             Text(L10n.History.total)
-                                .font(.system(size: 11, weight: .medium))
+                                .font(.system(size: 10, weight: .medium))
                                 .foregroundStyle(.secondary)
                             
                             Text(String(format: "$%.2f", totals.totalCost))
-                                .font(.system(size: 20, weight: .bold, design: .rounded))
+                                .font(.system(size: 16, weight: .semibold, design: .rounded))
                                 .foregroundStyle(.primary)
                             
-                            Text("\(NumberFormatters.formatTokens(totals.totalTokens)) tokens")
-                                .font(.system(size: 10))
+                            Text(NumberFormatters.formatTokens(totals.totalTokens))
+                                .font(.system(size: 9))
                                 .foregroundStyle(.secondary)
                         }
                     }
@@ -94,21 +94,21 @@ struct HistoryView: View {
                             .fill(Color.green.opacity(0.15))
                             .frame(height: 100)
                         
-                        VStack(spacing: 6) {
+                        VStack(spacing: 4) {
                             Image(systemName: "chart.line.uptrend.xyaxis")
-                                .font(.system(size: 22))
+                                .font(.system(size: 20))
                                 .foregroundStyle(.green)
                             
                             Text(L10n.History.dailyAverage)
-                                .font(.system(size: 11, weight: .medium))
+                                .font(.system(size: 10, weight: .medium))
                                 .foregroundStyle(.secondary)
                             
                             Text(String(format: "$%.2f", totals.totalCost / Double(viewModel.dailyData.count)))
-                                .font(.system(size: 20, weight: .bold, design: .rounded))
+                                .font(.system(size: 16, weight: .semibold, design: .rounded))
                                 .foregroundStyle(.primary)
                             
                             Text(L10n.History.perDay)
-                                .font(.system(size: 10))
+                                .font(.system(size: 9))
                                 .foregroundStyle(.secondary)
                         }
                     }
@@ -120,22 +120,22 @@ struct HistoryView: View {
                             .fill(Color.orange.opacity(0.15))
                             .frame(height: 100)
                         
-                        VStack(spacing: 6) {
+                        VStack(spacing: 4) {
                             Image(systemName: "flame.fill")
-                                .font(.system(size: 22))
+                                .font(.system(size: 20))
                                 .foregroundStyle(.orange)
                             
                             Text(L10n.History.peak)
-                                .font(.system(size: 11, weight: .medium))
+                                .font(.system(size: 10, weight: .medium))
                                 .foregroundStyle(.secondary)
                             
                             if let peak = viewModel.dailyData.max(by: { $0.totalCost < $1.totalCost }) {
                                 Text(String(format: "$%.2f", peak.totalCost))
-                                    .font(.system(size: 20, weight: .bold, design: .rounded))
+                                    .font(.system(size: 16, weight: .semibold, design: .rounded))
                                     .foregroundStyle(.primary)
                                 
                                 Text(self.formatPeakDate(peak.date))
-                                    .font(.system(size: 10))
+                                    .font(.system(size: 9))
                                     .foregroundStyle(.secondary)
                             }
                         }

--- a/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/Tabs/HistoryView.swift
@@ -47,70 +47,50 @@ struct HistoryView: View {
 
                 // 月間サマリー（インライン）
                 if !viewModel.isLoading && !viewModel.dailyData.isEmpty, let totals = viewModel.monthlyTotals {
-                    HStack(spacing: 4) {
+                    HStack(spacing: 16) {
                         // 合計
-                        HStack(spacing: 12) {
-                            VStack(spacing: 4) {
-                                Image(systemName: "chart.bar.fill")
-                                    .font(.system(size: 16))
-                                    .foregroundStyle(.blue)
-                                    .frame(width: 20, height: 20)
-                                
-                                Text(L10n.History.total)
-                                    .font(.system(size: 9, weight: .medium))
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack(spacing: 4) {
+                                Image(systemName: "dollarsign.circle.fill")
+                                    .font(.system(size: 12))
                                     .foregroundStyle(.secondary)
-                            }
-                            
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(String(format: "$%.0f", totals.totalCost))
-                                    .font(.system(size: 16, weight: .semibold, design: .rounded))
-                                    .foregroundStyle(.primary)
-                                Text("\(NumberFormatters.formatTokens(totals.totalTokens))")
+                                Text(L10n.History.total)
                                     .font(.system(size: 11, weight: .medium))
                                     .foregroundStyle(.secondary)
                             }
+                            Text(String(format: "$%.0f", totals.totalCost))
+                                .font(.system(size: 16, weight: .semibold, design: .rounded))
+                            Text("\(NumberFormatters.formatTokens(totals.totalTokens))")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
                         }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 10)
-                        .frame(maxWidth: .infinity)
-                        .background(
-                            RoundedRectangle(cornerRadius: 10)
-                                .fill(Color(NSColor.controlBackgroundColor))
-                                .opacity(0.8)
-                        )
+                        
+                        Divider()
+                            .frame(height: 36)
                         
                         // 日次平均
-                        HStack(spacing: 12) {
-                            VStack(spacing: 4) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack(spacing: 4) {
                                 Image(systemName: "calendar.day.timeline.left")
-                                    .font(.system(size: 16))
-                                    .foregroundStyle(.green)
-                                    .frame(width: 20, height: 20)
-                                
-                                Text(L10n.History.dailyAverage)
-                                    .font(.system(size: 9, weight: .medium))
+                                    .font(.system(size: 12))
                                     .foregroundStyle(.secondary)
-                            }
-                            
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(String(format: "$%.0f", totals.totalCost / Double(viewModel.dailyData.count)))
-                                    .font(.system(size: 16, weight: .semibold, design: .rounded))
-                                    .foregroundStyle(.primary)
-                                Text(L10n.History.perDay)
+                                Text(L10n.History.dailyAverage)
                                     .font(.system(size: 11, weight: .medium))
                                     .foregroundStyle(.secondary)
                             }
+                            Text(String(format: "$%.0f", totals.totalCost / Double(viewModel.dailyData.count)))
+                                .font(.system(size: 16, weight: .semibold, design: .rounded))
+                            Text(L10n.History.perDay)
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
                         }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 10)
-                        .frame(maxWidth: .infinity)
-                        .background(
-                            RoundedRectangle(cornerRadius: 10)
-                                .fill(Color(NSColor.controlBackgroundColor))
-                                .opacity(0.8)
-                        )
                     }
-                    .padding(.horizontal, 2)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color(NSColor.controlBackgroundColor))
+                    )
                 }
 
                 Spacer()


### PR DESCRIPTION
## Summary
- Historyタブの多言語対応を修正
- 月間合計トークン数の表示を追加
- カラフルなカードデザインでCurrentタブと統一感のあるUIを実現

## Changes
- 🌐 HistoryタブのUIテキストの多言語対応（日本語・英語）を完全に実装
- 📊 月間サマリーをカラフルなカード形式で表示（合計・日次平均・ピーク）
- 🎨 各指標にSF Symbolsアイコンと色付き背景を追加
- 🔧 コンパクトな日次カードデザインで9:16比率のスクリーンショット共有に最適化
- 💫 視覚的階層を持つHIGに準拠したデザイン

## Screenshots
実装後は以下のような見た目になります：
- 合計：青色カード with dollarsign.circle.fill アイコン
- 日次平均：緑色カード with chart.line.uptrend.xyaxis アイコン  
- ピーク：オレンジ色カード with flame.fill アイコン

## Test plan
- [x] 日本語環境で正しく表示されることを確認
- [x] 英語環境で正しく表示されることを確認
- [x] 月間データが正しく集計・表示されることを確認
- [x] スクリーンショット共有機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)