### PR TITLE
Fix: /start-work command execution flow

### DIFF
--- a/.claude/commands/start-work.md
+++ b/.claude/commands/start-work.md
@@ -3,67 +3,44 @@ description: 作業環境をセットアップしてClaude Codeを起動
 allowed-tools: Bash(git *), Bash(tmux *), Read, Write
 ---
 
-作業を開始するための環境を自動セットアップしてClaude Codeを起動します。
+## 環境確認
+- Git status: !`git status --porcelain | head -5 || echo "✅ 作業ツリーはクリーンです"`
+- Tmux: !`which tmux >/dev/null && echo "✅ tmux is installed" || echo "❌ tmux not found"`
+- 現在のブランチ: !`git branch --show-current`
+- 既存のworktrees: !`git worktree list | tail -n +2 || echo "No worktrees found"`
 
-## 現在の環境確認
+## タスク
+作業内容: **{{ARGUMENTS}}**
 
-### Git状態
-!`git status --porcelain | head -5 || echo "✅ 作業ツリーはクリーンです"`
+以下の手順で作業環境をセットアップしてください：
 
-### 現在のブランチ
-!`git branch --show-current`
-
-### Tmuxインストール確認
-!`which tmux >/dev/null && echo "✅ tmux is installed" || echo "❌ tmux not found - please install tmux first"`
-
-### 既存のworktrees
-!`git worktree list | tail -n +2 || echo "No worktrees found"`
-
-## 作業開始の準備
-
-作業概要: **{{ARGUMENTS}}**
-
-この作業概要から以下を実行します：
-
-1. **ブランチタイプの判定**
+1. まず、作業内容から適切なブランチタイプとブランチ名を決定してください：
    - 「実装」「追加」「機能」→ `feature/`
-   - 「修正」「バグ」「エラー」→ `fix/`
+   - 「修正」「バグ」「エラー」「失敗」→ `fix/`
    - 「更新」「ドキュメント」「README」→ `docs/`
    - 「リファクタ」「改善」→ `refactor/`
    - その他 → `chore/`
 
-2. **ブランチ名の生成**
-   - 日本語を英語に変換
+2. ブランチ名は以下のルールで生成してください：
+   - 日本語を英語に変換（例：リリース→release、失敗→failure、調査→investigate）
    - スペースをハイフンに変換
    - 小文字に統一
 
-3. **環境セットアップ**
-   - developブランチの最新を取得
-   - worktreeを作成
-   - tmuxセッションを開始
-   - Claude Codeを起動
+3. 以下のコマンドを実行してください：
 
-## 実行
+```bash
+# developブランチを更新
+git fetch origin develop:develop
 
-まず、未コミットの変更がないか確認します。変更がある場合は、先にコミットまたはstashしてください。
+# worktreeを作成（ブランチ名を適切に置き換えてください）
+git worktree add -b [ブランチタイプ]/[ブランチ名] ../worktrees/[ブランチ名] develop
 
-次に、以下の処理を実行します：
+# tmuxセッションを作成してClaude Codeを起動
+tmux new-session -d -s claude-[ブランチ名] -c ../worktrees/[ブランチ名] "claude code"
+```
 
-### 1. developブランチの更新
-!`git fetch origin develop:develop`
-
-### 2. ブランチ名の決定
-作業概要に基づいて適切なブランチ名を生成します。
-
-### 3. worktreeとセッションの作成
-
-実際の作業は以下のステップで行います：
-
-1. ブランチタイプとブランチ名を決定
-2. worktreeを作成
-3. tmuxセッションでClaude Codeを起動
-
-**注意**: 
-- worktreeは `../worktrees/` ディレクトリに作成されます
-- tmuxセッション名は `claude-{branch-name}` となります
-- 作業が完了したら `git worktree remove` でworktreeを削除してください
+4. セッション作成後、以下の情報を表示してください：
+   - 接続方法: `tmux attach -t claude-[ブランチ名]`
+   - 片付け方法:
+     - `tmux kill-session -t claude-[ブランチ名]`
+     - `git worktree remove ../worktrees/[ブランチ名]`


### PR DESCRIPTION
## Summary
- /start-work コマンドがClaude Codeに適切にbashコマンドを実行させるように修正
- 事前実行（`\!`）から指示形式に変更し、Claude Codeがタスクを解釈して実行するフローに改善

## Changes
- `\!`で囲まれたbashスクリプトを削除し、環境確認のみに使用
- Claude Codeへの指示として明確なステップを記述
- ブランチ名生成ロジックをClaude Codeに委譲

## Test plan
- [ ] `/start-work リリースがsparkle周りで失敗するので調査したい` でfix/ブランチが作成されること
- [ ] worktreeが正しく作成されること
- [ ] tmuxセッションが起動されること

🤖 Generated with [Claude Code](https://claude.ai/code)