### PR TITLE
Sparkleの署名生成エラーを修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [0.7.8] - 2025-07-06
+
+### Fixed
+- Sparkle署名生成の非推奨フラグを修正 (generate-appcast.sh, sign-update.sh)
+
 ## [0.7.7] - 2025-07-06
 
 ### Fixed

--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.7</string>
+	<string>0.7.8</string>
 	<key>CFBundleVersion</key>
-	<string>0.7.7</string>
+	<string>0.7.8</string>
 	<key>CcusageVersion</key>
 	<string>15.3.0</string>
 	<key>LSMinimumSystemVersion</key>

--- a/scripts/generate-appcast.sh
+++ b/scripts/generate-appcast.sh
@@ -53,7 +53,7 @@ echo "Generating signature for $DMG_PATH..."
 # Write private key to temporary file with secure permissions
 PRIVATE_KEY_FILE="$TEMP_DIR/private_key.txt"
 (umask 077 && echo "$SPARKLE_PRIVATE_KEY" > "$PRIVATE_KEY_FILE")
-SIGNATURE=$("$SIGN_UPDATE" -s "$PRIVATE_KEY_FILE" "$DMG_PATH" | awk '/sparkle:edSignature=/ {print $2}' | tr -d '"')
+SIGNATURE=$("$SIGN_UPDATE" -f "$PRIVATE_KEY_FILE" "$DMG_PATH" | awk '/sparkle:edSignature=/ {print $2}' | tr -d '"')
 
 # Immediately remove the private key file after use
 rm -f "$PRIVATE_KEY_FILE"

--- a/scripts/generate-appcast.sh
+++ b/scripts/generate-appcast.sh
@@ -53,7 +53,7 @@ echo "Generating signature for $DMG_PATH..."
 # Write private key to temporary file with secure permissions
 PRIVATE_KEY_FILE="$TEMP_DIR/private_key.txt"
 (umask 077 && echo "$SPARKLE_PRIVATE_KEY" > "$PRIVATE_KEY_FILE")
-SIGNATURE=$("$SIGN_UPDATE" -f "$PRIVATE_KEY_FILE" "$DMG_PATH" | awk '/sparkle:edSignature=/ {print $2}' | tr -d '"')
+SIGNATURE=$("$SIGN_UPDATE" -f "$PRIVATE_KEY_FILE" -p "$DMG_PATH")
 
 # Immediately remove the private key file after use
 rm -f "$PRIVATE_KEY_FILE"

--- a/scripts/sign-update.sh
+++ b/scripts/sign-update.sh
@@ -46,7 +46,12 @@ fi
 
 # Generate EdDSA signature
 echo "Generating signature for $FILE_TO_SIGN..."
-SIGNATURE=$("$SIGN_UPDATE" -f "$SPARKLE_PRIVATE_KEY" "$FILE_TO_SIGN" | tail -1)
+# Write private key to temporary file with secure permissions
+PRIVATE_KEY_FILE="$TEMP_DIR/private_key.txt"
+(umask 077 && echo "$SPARKLE_PRIVATE_KEY" > "$PRIVATE_KEY_FILE")
+SIGNATURE=$("$SIGN_UPDATE" -f "$PRIVATE_KEY_FILE" "$FILE_TO_SIGN" | tail -1)
+# Immediately remove the private key file after use
+rm -f "$PRIVATE_KEY_FILE"
 
 if [ -z "$SIGNATURE" ]; then
     echo "Error: Failed to generate signature"

--- a/scripts/sign-update.sh
+++ b/scripts/sign-update.sh
@@ -49,7 +49,7 @@ echo "Generating signature for $FILE_TO_SIGN..."
 # Write private key to temporary file with secure permissions
 PRIVATE_KEY_FILE="$TEMP_DIR/private_key.txt"
 (umask 077 && echo "$SPARKLE_PRIVATE_KEY" > "$PRIVATE_KEY_FILE")
-SIGNATURE=$("$SIGN_UPDATE" -f "$PRIVATE_KEY_FILE" "$FILE_TO_SIGN" | tail -1)
+SIGNATURE=$("$SIGN_UPDATE" -f "$PRIVATE_KEY_FILE" -p "$FILE_TO_SIGN")
 # Immediately remove the private key file after use
 rm -f "$PRIVATE_KEY_FILE"
 


### PR DESCRIPTION
## Summary
- generate-appcast.shとsign-update.shで非推奨の`-s`フラグを`-f`に変更
- 秘密鍵を一時ファイル経由で渡すように修正

## 詳細
Sparkleの`sign_update`コマンドが署名生成に失敗していた問題を修正しました。

### 問題
- `-s`フラグは非推奨で、正しくは`-f`フラグを使用する必要がある
- `-f`フラグはファイルパスを期待するため、環境変数の値を直接渡すことができない

### 修正内容
1. 両スクリプトで`-s`を`-f`に変更
2. 環境変数の秘密鍵を一時ファイルに書き出してから使用
3. セキュリティのため、umask 077で権限を制限し、使用後は即座に削除

## Test plan
- [ ] ローカルでスクリプトが正常に動作することを確認
- [ ] GitHub Actionsでリリースワークフローが成功することを確認
- [ ] 生成されたappcast.xmlに正しい署名が含まれることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)