### PR TITLE
fix: Sparkle CI環境でのsign_updateツールパス問題を修正

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -79,6 +79,11 @@ jobs:
           name: dmg-artifact
           path: .
 
+      - name: Setup Sparkle
+        uses: jozefizso/setup-sparkle@v1
+        with:
+          version: 2.6.2
+
       - name: Generate Sparkle appcast
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [0.7.9] - 2025-07-06
+
+### Fixed
+- CI環境でSparkleの`sign_update`ツールが見つからない問題を修正
+- setup-sparkle GitHub Actionを導入してSparkleツールのセットアップを自動化
+- Sparkleを最新のセキュリティバージョン(2.6.2)に更新
+
 ## [0.7.8] - 2025-07-06
 
 ### Fixed

--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.8</string>
+	<string>0.7.9</string>
 	<key>CFBundleVersion</key>
-	<string>0.7.8</string>
+	<string>0.7.9</string>
 	<key>CcusageVersion</key>
 	<string>15.3.0</string>
 	<key>LSMinimumSystemVersion</key>

--- a/scripts/generate-appcast.sh
+++ b/scripts/generate-appcast.sh
@@ -28,24 +28,54 @@ DOWNLOAD_URL="${REPO_URL}/releases/download/v${VERSION}/ClaudeCodeMonitor-${VERS
 FILE_SIZE=$(stat -f%z "$DMG_PATH")
 RELEASE_DATE=$(date -u +"%a, %d %b %Y %H:%M:%S %z")
 
-# Create temporary directory for Sparkle tools
-TEMP_DIR=$(mktemp -d)
-trap "rm -rf $TEMP_DIR" EXIT
+# Check if we're in CI environment with setup-sparkle
+if [ -n "${SPARKLE_BIN:-}" ] && [ -f "$SPARKLE_BIN/sign_update" ]; then
+    echo "Using Sparkle tools from setup-sparkle action: $SPARKLE_BIN"
+    SIGN_UPDATE="$SPARKLE_BIN/sign_update"
+else
+    # Create temporary directory for Sparkle tools
+    TEMP_DIR=$(mktemp -d)
+    trap "rm -rf $TEMP_DIR" EXIT
 
-# Download Sparkle tools if not available
-SPARKLE_VERSION="2.5.2"
-SPARKLE_TOOLS_URL="https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+    # Download Sparkle tools if not available
+    SPARKLE_VERSION="2.6.2"
+    SPARKLE_TOOLS_URL="https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
 
-echo "Downloading Sparkle tools..."
-curl -L -o "$TEMP_DIR/sparkle.tar.xz" "$SPARKLE_TOOLS_URL"
-tar -xf "$TEMP_DIR/sparkle.tar.xz" -C "$TEMP_DIR"
+    echo "Downloading Sparkle tools..."
+    if ! curl -L -o "$TEMP_DIR/sparkle.tar.xz" "$SPARKLE_TOOLS_URL"; then
+        echo "Error: Failed to download Sparkle tools from $SPARKLE_TOOLS_URL"
+        exit 1
+    fi
 
-# Path to sign_update tool
-SIGN_UPDATE="$TEMP_DIR/Sparkle.framework/Versions/Current/Resources/sign_update"
+    echo "Extracting Sparkle tools..."
+    if ! tar -xf "$TEMP_DIR/sparkle.tar.xz" -C "$TEMP_DIR"; then
+        echo "Error: Failed to extract Sparkle tools"
+        exit 1
+    fi
 
-if [ ! -f "$SIGN_UPDATE" ]; then
-    echo "Error: sign_update tool not found at $SIGN_UPDATE"
-    exit 1
+    # Path to sign_update tool
+    SIGN_UPDATE="$TEMP_DIR/bin/sign_update"
+
+    if [ ! -f "$SIGN_UPDATE" ]; then
+        echo "Error: sign_update tool not found at $SIGN_UPDATE"
+        echo "Checking alternative locations..."
+        
+        # Check alternative paths
+        for path in "$TEMP_DIR/Sparkle.framework/Versions/Current/Resources/sign_update" "$TEMP_DIR/sign_update"; do
+            if [ -f "$path" ]; then
+                echo "Found sign_update at: $path"
+                SIGN_UPDATE="$path"
+                break
+            fi
+        done
+        
+        if [ ! -f "$SIGN_UPDATE" ]; then
+            echo "Error: Could not find sign_update tool in any expected location"
+            echo "Contents of temp directory:"
+            find "$TEMP_DIR" -name "sign_update" -type f 2>/dev/null || true
+            exit 1
+        fi
+    fi
 fi
 
 # Generate EdDSA signature


### PR DESCRIPTION
## Summary
- CI環境でSparkleの`sign_update`ツールが見つからない問題を修正
- setup-sparkle GitHub Actionを導入してツールのセットアップを自動化
- generate-appcast.shスクリプトを改善してCI/ローカル両環境に対応

## Changes
- `.github/workflows/release-common.yml`: setup-sparkle@v1アクションを追加
- `scripts/generate-appcast.sh`: 
  - CI環境では`$SPARKLE_BIN`環境変数を優先的に使用
  - sign_updateツールの正しいパス（`bin/sign_update`）を使用
  - Sparkleバージョンを2.6.2（セキュリティアップデート）に更新
  - エラーハンドリングを強化

## Test plan
- [ ] CI環境でリリースワークフローが正常に動作することを確認
- [ ] ローカル環境でgenerate-appcast.shが引き続き動作することを確認
- [ ] Sparkle appcast.xmlが正しく生成されることを確認

## Related
- Fixes #71 のCI失敗問題

🤖 Generated with [Claude Code](https://claude.ai/code)