### PR TITLE
fix: アプリ起動時のSparkle.framework読み込みエラーを修正

### DIFF
--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -188,8 +188,18 @@ jobs:
         echo "=== App bundle root after cleanup ==="
         ls -la "ClaudeCodeMonitor.app/"
         
-        # Try signing (without --deep to preserve Node.js signature)
-        echo "=== Attempting to sign ==="
+        # Sign Sparkle.framework first if it exists
+        if [ -d "ClaudeCodeMonitor.app/Contents/Frameworks/Sparkle.framework" ]; then
+          echo "=== Signing Sparkle.framework ==="
+          codesign --force --strict \
+            --options runtime \
+            --sign "$CERT_NAME" \
+            --timestamp \
+            "ClaudeCodeMonitor.app/Contents/Frameworks/Sparkle.framework"
+        fi
+        
+        # Try signing (without --deep to preserve framework signatures)
+        echo "=== Attempting to sign app ==="
         codesign --force --strict \
           --options runtime \
           --entitlements ClaudeCodeMonitor.entitlements \

--- a/scripts/create-app-bundle.sh
+++ b/scripts/create-app-bundle.sh
@@ -79,6 +79,10 @@ mkdir -p "$APP_PATH/Contents/"{MacOS,Resources}
 echo "  Copying executable..."
 cp "$UNIVERSAL_PATH" "$APP_PATH/Contents/MacOS/ClaudeCodeMonitor"
 
+# Add rpath for Frameworks directory
+echo "  Adding rpath for Frameworks..."
+install_name_tool -add_rpath "@loader_path/../Frameworks" "$APP_PATH/Contents/MacOS/ClaudeCodeMonitor"
+
 # Copy Info.plist and update version
 echo "  Copying Info.plist..."
 cp Info.plist "$APP_PATH/Contents/Info.plist"
@@ -86,6 +90,20 @@ cp Info.plist "$APP_PATH/Contents/Info.plist"
 echo "  Updating version to $VERSION..."
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$APP_PATH/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION" "$APP_PATH/Contents/Info.plist"
+
+# Create Frameworks directory
+mkdir -p "$APP_PATH/Contents/Frameworks"
+
+# Copy Sparkle.framework
+echo "  Looking for Sparkle.framework..."
+SPARKLE_FRAMEWORK=$(find .build -path "*/artifacts/sparkle/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework" -type d | head -1)
+if [ -n "$SPARKLE_FRAMEWORK" ] && [ -d "$SPARKLE_FRAMEWORK" ]; then
+    echo "    Found Sparkle.framework: $SPARKLE_FRAMEWORK"
+    cp -R "$SPARKLE_FRAMEWORK" "$APP_PATH/Contents/Frameworks/"
+    echo "    Sparkle.framework copied"
+else
+    echo "    ⚠️  Sparkle.framework not found"
+fi
 
 # Copy resource bundles from arm64 build (they are identical across architectures)
 echo "  Looking for resource bundles..."


### PR DESCRIPTION
## Summary
- DMGからインストールしたアプリが起動しない問題を修正
- Sparkle.frameworkがアプリケーションバンドルに含まれていなかった

## Problem
- Swift Package Managerでビルドした際、Sparkleフレームワークが実行ファイルに静的リンクされず、動的フレームワークとして期待されていた
- しかし、フレームワークがアプリケーションバンドルに含まれていなかったため、起動時に`dyld: Library not loaded`エラーが発生

## Changes
- `create-app-bundle.sh`:
  - Sparkle.frameworkをFrameworksディレクトリにコピーする処理を追加
  - rpathに`@loader_path/../Frameworks`を追加
- `build-and-sign.yml`:
  - Sparkle.frameworkを個別に署名する処理を追加

## Test plan
- [ ] ローカルでアプリをビルドして起動確認
- [ ] CI/CDでビルドされたDMGからアプリをインストールして起動確認
- [ ] Code signingが正しく動作することを確認

## Related
- 前のPR #73 の続き

🤖 Generated with [Claude Code](https://claude.ai/code)