### PR TITLE
fix: Xcode 16.0とSparkle 2.7.1に更新してCI失敗を修正

### DIFF
--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -46,7 +46,7 @@ jobs:
     
     - name: Select Xcode
       env:
-        XCODE_VERSION: '15.2'
+        XCODE_VERSION: '16.0'
       run: sudo xcode-select -s "/Applications/Xcode_${XCODE_VERSION}.app"
     
     # Check if we have signing certificates

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -105,7 +105,7 @@ jobs:
             # Download and extract Sparkle
             echo "Downloading Sparkle tools..."
             cd sparkle
-            curl -Lo sparkle.tar.xz https://github.com/sparkle-project/Sparkle/releases/download/2.6.4/Sparkle-2.6.4.tar.xz
+            curl -Lo sparkle.tar.xz https://github.com/sparkle-project/Sparkle/releases/download/2.7.1/Sparkle-2.7.1.tar.xz
             tar xzf sparkle.tar.xz
             cd ..
             

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [0.7.12] - 2025-07-06
+
+### Fixed
+- CI/CDパイプラインのビルドエラーを修正
+  - GitHub ActionsのmacOS-latestランナーでXcode 15.xが利用不可になったため、Xcode 16.0に更新
+  - Sparkleフレームワークとツールを最新の2.7.1に統一
+
 ## [0.7.11] - 2025-07-06
 
 ### Added

--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.11</string>
+	<string>0.7.12</string>
 	<key>CFBundleVersion</key>
-	<string>0.7.11</string>
+	<string>0.7.12</string>
 	<key>CcusageVersion</key>
 	<string>15.3.0</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.5.2")
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.1")
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
## Summary
- GitHub ActionsのCDが失敗していた問題を修正
- Xcodeバージョンを16.0に更新（macOS-latestランナーで15.xが利用不可）
- Sparkleを最新版2.7.1に統一

## Changes
- `.github/workflows/build-and-sign.yml`: Xcode 15.2 → 16.0
- `Package.swift`: Sparkle 2.5.2 → 2.7.1
- `.github/workflows/release-common.yml`: Sparkleツール 2.6.4 → 2.7.1
- バージョンを0.7.12に更新

## Test plan
- [x] ローカルでビルドテストを実施（成功）
- [ ] CIが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)