### PR TITLE
fix: Xcode 16.2を使用するように修正（macOS 14対応）

### DIFF
--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -46,7 +46,7 @@ jobs:
     
     - name: Select Xcode
       env:
-        XCODE_VERSION: '16.0'
+        XCODE_VERSION: '16.2'
       run: sudo xcode-select -s "/Applications/Xcode_${XCODE_VERSION}.app"
     
     # Check if we have signing certificates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Select Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.2.app
+      env:
+        XCODE_VERSION: '16.2'
+      run: sudo xcode-select -s "/Applications/Xcode_${XCODE_VERSION}.app"
     
     - name: Build Debug
       run: swift build -v
@@ -39,7 +41,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Select Xcode
-      run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      run: sudo xcode-select -s "/Applications/Xcode_${{ matrix.xcode }}.app"
     
     - name: Show Swift version
       run: swift --version
@@ -62,7 +64,7 @@ jobs:
         swift test --filter ViewModelTests -v)
     
     - name: Generate coverage report
-      if: matrix.xcode == '15.2'
+      if: matrix.xcode == '16.2'
       run: |
         xcrun llvm-cov export \
           .build/debug/ClaudeCodeMonitorPackageTests.xctest/Contents/MacOS/ClaudeCodeMonitorPackageTests \
@@ -70,7 +72,7 @@ jobs:
           -format="lcov" > coverage.lcov
     
     - name: Upload coverage to Codecov
-      if: matrix.xcode == '15.2'
+      if: matrix.xcode == '16.2'
       uses: codecov/codecov-action@v4
       with:
         file: ./coverage.lcov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [0.7.13] - 2025-07-06
+
+### Fixed
+- GitHub ActionsでのXcodeバージョン指定を修正
+  - Xcode 16.0はmacOS 14ランナーで利用不可のため、16.2を使用
+  - CI設定の一貫性を改善（環境変数方式で統一）
+  - テストカバレッジ生成条件を最新のXcodeバージョンに更新
+
 ## [0.7.12] - 2025-07-06
 
 ### Fixed

--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.12</string>
+	<string>0.7.13</string>
 	<key>CFBundleVersion</key>
-	<string>0.7.12</string>
+	<string>0.7.13</string>
 	<key>CcusageVersion</key>
 	<string>15.3.0</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary
GitHub ActionsのCDが失敗していた問題の追加修正です。

## Problem
- macOS-latest (macOS 14)でXcode 16.0が2025年1月6日に削除された
- 前回の修正でXcode 16.0を指定したが、実際には利用できなかった

## Changes
### build-and-sign.yml
- Xcode 16.0 → 16.2に変更

### ci.yml
- ビルドジョブでXcode設定を環境変数方式に統一
- テストカバレッジ生成条件を15.2から16.2に更新
- Xcodeパスをクォートで囲むように修正

## Available Xcode versions
- **macOS 14**: 15.0.1〜15.4、16.1、16.2
- **macOS 15**: 16.0〜16.4

現時点では安定性を重視してmacOS 14 + Xcode 16.2を使用します。

## Test plan
- [x] ローカルでビルドテスト実施
- [ ] CIが正常に動作することを確認
- [ ] Development Releaseワークフローが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)