### PR TITLE
fix: Sparkle.framework内のすべてのバイナリを適切に署名してnotarization失敗を修正

### DIFF
--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -188,28 +188,61 @@ jobs:
         echo "=== App bundle root after cleanup ==="
         ls -la "ClaudeCodeMonitor.app/"
         
-        # Sign Sparkle.framework first if it exists
+        # Sign Sparkle.framework components if it exists
         if [ -d "ClaudeCodeMonitor.app/Contents/Frameworks/Sparkle.framework" ]; then
-          echo "=== Signing Sparkle.framework ==="
-          codesign --force --strict \
-            --options runtime \
-            --sign "$CERT_NAME" \
-            --timestamp \
+          echo "=== Signing Sparkle.framework components ==="
+          
+          # Sign individual binaries first
+          if [ -f "ClaudeCodeMonitor.app/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate" ]; then
+            echo "  Signing Autoupdate binary..."
+            codesign --force --options runtime --sign "$CERT_NAME" --timestamp \
+              "ClaudeCodeMonitor.app/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate"
+          fi
+          
+          if [ -f "ClaudeCodeMonitor.app/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle" ]; then
+            echo "  Signing Sparkle binary..."
+            codesign --force --options runtime --sign "$CERT_NAME" --timestamp \
+              "ClaudeCodeMonitor.app/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle"
+          fi
+          
+          # Sign Updater.app
+          if [ -d "ClaudeCodeMonitor.app/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app" ]; then
+            echo "  Signing Updater.app..."
+            codesign --force --deep --options runtime --sign "$CERT_NAME" --timestamp \
+              "ClaudeCodeMonitor.app/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app"
+          fi
+          
+          # Sign XPCServices
+          if [ -d "ClaudeCodeMonitor.app/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices" ]; then
+            echo "  Signing XPC Services..."
+            find "ClaudeCodeMonitor.app/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices" \
+              -name "*.xpc" -exec codesign --force --deep --options runtime --sign "$CERT_NAME" --timestamp {} \;
+          fi
+          
+          # Finally sign the framework itself
+          echo "  Signing Sparkle.framework..."
+          codesign --force --options runtime --sign "$CERT_NAME" --timestamp \
             "ClaudeCodeMonitor.app/Contents/Frameworks/Sparkle.framework"
         fi
         
-        # Try signing (without --deep to preserve framework signatures)
-        echo "=== Attempting to sign app ==="
-        codesign --force --strict \
+        # Sign the app with --deep to ensure all components are signed
+        echo "=== Attempting to sign app with --deep ==="
+        codesign --force --deep --strict \
           --options runtime \
           --entitlements ClaudeCodeMonitor.entitlements \
           --sign "$CERT_NAME" \
           --timestamp \
           "ClaudeCodeMonitor.app"
         
-        # Verify signature
-        codesign --verify --deep --strict --verbose=2 "ClaudeCodeMonitor.app"
+        # Verify signature with detailed output
+        echo "=== Verifying signature ==="
+        codesign --verify --deep --strict --verbose=4 "ClaudeCodeMonitor.app"
+        
+        echo "=== Signature details ==="
         codesign -dvvv "ClaudeCodeMonitor.app"
+        
+        echo "=== Verifying with spctl ==="
+        spctl -a -vvv -t install "ClaudeCodeMonitor.app" || echo "Note: spctl check may fail in CI environment"
     
     # Ad-hoc sign if no certificates
     - name: Ad-hoc sign app bundle
@@ -278,8 +311,26 @@ jobs:
       if: steps.check_signing.outputs.has_signing_cert == 'true' && steps.check_signing.outputs.has_notarization == 'true'
       run: |
         echo "📎 Stapling notarization..."
-        xcrun stapler staple "$DMG_PATH"
-        xcrun stapler validate "$DMG_PATH"
+        echo "DMG_PATH: $DMG_PATH"
+        
+        # Check if DMG exists
+        if [ ! -f "$DMG_PATH" ]; then
+          echo "❌ DMG file not found at: $DMG_PATH"
+          ls -la
+          exit 1
+        fi
+        
+        # Verify DMG signature before stapling
+        echo "=== Verifying DMG signature before stapling ==="
+        codesign --verify --verbose=2 "$DMG_PATH"
+        
+        # Attempt to staple
+        echo "=== Stapling notarization ticket ==="
+        xcrun stapler staple -v "$DMG_PATH"
+        
+        # Validate the staple
+        echo "=== Validating stapled notarization ==="
+        xcrun stapler validate -v "$DMG_PATH"
     
     # Generate changelog for development releases
     - name: Generate changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [0.7.14] - 2025-07-06
+
+### Fixed
+- Staple notarization失敗を修正
+  - Sparkle.framework内のすべてのバイナリ（Autoupdate、Sparkle、Updater.app、XPCServices）を個別に署名
+  - アプリ全体の署名に--deepオプションを追加
+  - 署名検証とデバッグ情報を強化
+
 ## [0.7.13] - 2025-07-06
 
 ### Fixed

--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.13</string>
+	<string>0.7.14</string>
 	<key>CFBundleVersion</key>
-	<string>0.7.13</string>
+	<string>0.7.14</string>
 	<key>CcusageVersion</key>
 	<string>15.3.0</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary
Staple notarizationがexit code 65で失敗していた問題を修正します。

## Problem
- GitHub Actionsでnotarization後のstapleステップが失敗
- 原因: Sparkle.framework内の実行可能ファイルが適切に署名されていなかった
- エラー: "The signature of the binary is invalid"

## Solution

### 1. Sparkle.framework内のコンポーネントを個別に署名
- `Autoupdate` バイナリ
- `Sparkle` バイナリ  
- `Updater.app`（--deepオプション付き）
- `XPCServices`内のすべての`.xpc`サービス

### 2. アプリ全体の署名を強化
- `--deep`オプションを追加して内部コンポーネントを確実に署名
- 署名検証を詳細モード（`verbose=4`）に変更
- `spctl`検証を追加（CI環境での失敗は許容）

### 3. デバッグ情報の追加
- staple前のDMG署名検証
- staplerコマンドの詳細出力（`-v`オプション）
- エラー時の詳細情報出力

## Reference
- [macOSアプリのSparkle導入時のNotarization問題について](https://zenn.dev/iseebi/articles/macos_sparkle_spm_ci_notarization_issue)
- Ukamプロジェクトの実装を参考

## Test plan
- [ ] CIでビルドが成功することを確認
- [ ] Notarizationプロセスが正常に完了することを確認
- [ ] Staple notarizationが成功することを確認
- [ ] リリースワークフロー全体が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)