### PR TITLE
feat: アップデートチャンネル機能を実装

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -125,17 +125,26 @@ jobs:
               -o appcast.xml \
               appcast/
             
+            # Determine which appcast file to create based on build type
+            if [ "${{ inputs.is_dev_build }}" == "true" ]; then
+              # For dev builds, create appcast-dev.xml
+              mv appcast.xml appcast-dev.xml
+              echo "✅ Successfully generated appcast-dev.xml"
+            else
+              # For stable builds, keep appcast.xml
+              echo "✅ Successfully generated appcast.xml"
+            fi
+            
             # Clean up
             rm -rf sparkle appcast
-            
-            if [ -f "appcast.xml" ]; then
-              echo "✅ Successfully generated appcast.xml"
-            else
-              echo "❌ Failed to generate appcast.xml"
-              exit 1
-            fi
           else
-            echo "⚠️ No Sparkle private key, creating empty appcast.xml"
+            if [ "${{ inputs.is_dev_build }}" == "true" ]; then
+              echo "⚠️ No Sparkle private key, creating empty appcast-dev.xml"
+              APPCAST_FILE="appcast-dev.xml"
+            else
+              echo "⚠️ No Sparkle private key, creating empty appcast.xml"
+              APPCAST_FILE="appcast.xml"
+            fi
             {
               echo '<?xml version="1.0" encoding="utf-8"?>'
               echo '<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">'
@@ -144,7 +153,7 @@ jobs:
               echo '    <description>No Sparkle key configured</description>'
               echo '  </channel>'
               echo '</rss>'
-            } > appcast.xml
+            } > "$APPCAST_FILE"
           fi
 
       - name: Create and push tag
@@ -209,4 +218,4 @@ jobs:
           prerelease: ${{ inputs.is_dev_build }}
           files: |
             *.dmg
-            appcast.xml
+            appcast*.xml

--- a/Sources/ClaudeUsageMonitor/App/AppDelegate.swift
+++ b/Sources/ClaudeUsageMonitor/App/AppDelegate.swift
@@ -22,15 +22,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     #if canImport(Sparkle)
         #if DEBUG
         // Allow testing Sparkle in debug builds with TEST_SPARKLE environment variable
-        private let updaterController: SPUStandardUpdaterController? = {
+        private lazy var updaterController: SPUStandardUpdaterController? = {
             if ProcessInfo.processInfo.environment["TEST_SPARKLE"] != nil {
                 print("⚠️ Sparkle enabled in DEBUG mode for testing")
-                return SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+                return SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
             }
             return nil
         }()
         #else
-        private let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+        private lazy var updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
         #endif
     #else
     private let updaterController: AnyObject? = nil
@@ -45,6 +45,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             print("Sparkle testing mode enabled")
         }
         #endif
+        
+        // Configure Sparkle update channel
+        configureUpdateChannel()
 
         // Perform synchronous environment check first
         environmentCheckResult = CommandExecutor.shared.checkEnvironmentSync()
@@ -231,7 +234,35 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         usageMonitor.stopMonitoring()
     }
+    
+    private func configureUpdateChannel() {
+        #if canImport(Sparkle)
+        let channel = UserDefaults.standard.updateChannel
+        print("Sparkle configured for \(channel.rawValue) channel: \(channel.appcastURL)")
+        #endif
+    }
+    
+    func updateChannelChanged(to newChannel: UpdateChannel) {
+        #if canImport(Sparkle)
+        guard let updater = updaterController?.updater else { return }
+        
+        print("Sparkle channel changed to \(newChannel.rawValue): \(newChannel.appcastURL)")
+        
+        // Check for updates with new channel
+        updater.checkForUpdates()
+        #endif
+    }
 }
+
+// MARK: - SPUUpdaterDelegate
+#if canImport(Sparkle)
+extension AppDelegate: SPUUpdaterDelegate {
+    nonisolated func feedURLString(for updater: SPUUpdater) -> String? {
+        let channel = UserDefaults.standard.updateChannel
+        return channel.appcastURL
+    }
+}
+#endif
 
 class EventMonitor {
     private var monitor: Any?

--- a/Sources/ClaudeUsageMonitor/Models/UpdateChannel.swift
+++ b/Sources/ClaudeUsageMonitor/Models/UpdateChannel.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+enum UpdateChannel: String, CaseIterable {
+    case stable = "stable"
+    case dev = "dev"
+    
+    var displayName: String {
+        switch self {
+        case .stable:
+            return L10n.Update.stableChannel
+        case .dev:
+            return L10n.Update.devChannel
+        }
+    }
+    
+    var appcastURL: String {
+        switch self {
+        case .stable:
+            return "https://github.com/K9i-0/ClaudeCodeMonitor/releases/latest/download/appcast.xml"
+        case .dev:
+            return "https://github.com/K9i-0/ClaudeCodeMonitor/releases/latest/download/appcast-dev.xml"
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .stable:
+            return L10n.Update.stableChannelDescription
+        case .dev:
+            return L10n.Update.devChannelDescription
+        }
+    }
+    
+    static func fromVersion(_ version: String) -> UpdateChannel {
+        // If version contains "-dev", it's a dev channel
+        return version.contains("-dev") ? .dev : .stable
+    }
+}

--- a/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/en.lproj/Localizable.strings
@@ -165,3 +165,8 @@
 "update.upToDate" = "You're up to date!";
 "update.available" = "Update available";
 "update.failed" = "Failed to check for updates";
+"update.updateChannel" = "Update Channel";
+"update.stableChannel" = "Stable";
+"update.devChannel" = "Development";
+"update.stableChannelDescription" = "Stable releases only";
+"update.devChannelDescription" = "Development builds and stable releases";

--- a/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/ClaudeUsageMonitor/Resources/ja.lproj/Localizable.strings
@@ -165,3 +165,8 @@
 "update.upToDate" = "最新の状態です！";
 "update.available" = "アップデートがあります";
 "update.failed" = "アップデート確認に失敗しました";
+"update.updateChannel" = "アップデートチャンネル";
+"update.stableChannel" = "安定版";
+"update.devChannel" = "開発版";
+"update.stableChannelDescription" = "安定版リリースのみ";
+"update.devChannelDescription" = "開発版ビルドと安定版リリース";

--- a/Sources/ClaudeUsageMonitor/Utils/Localization.swift
+++ b/Sources/ClaudeUsageMonitor/Utils/Localization.swift
@@ -306,5 +306,10 @@ struct L10n {
         static var upToDate: String { "update.upToDate".localized }
         static var available: String { "update.available".localized }
         static var failed: String { "update.failed".localized }
+        static var updateChannel: String { "update.updateChannel".localized }
+        static var stableChannel: String { "update.stableChannel".localized }
+        static var devChannel: String { "update.devChannel".localized }
+        static var stableChannelDescription: String { "update.stableChannelDescription".localized }
+        static var devChannelDescription: String { "update.devChannelDescription".localized }
     }
 }

--- a/Sources/ClaudeUsageMonitor/Utils/UserDefaults+UpdateChannel.swift
+++ b/Sources/ClaudeUsageMonitor/Utils/UserDefaults+UpdateChannel.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+extension UserDefaults {
+    private enum Keys {
+        static let updateChannel = "UpdateChannel"
+    }
+    
+    var updateChannel: UpdateChannel {
+        get {
+            guard let rawValue = string(forKey: Keys.updateChannel),
+                  let channel = UpdateChannel(rawValue: rawValue) else {
+                // Auto-detect based on current version
+                let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+                return UpdateChannel.fromVersion(version)
+            }
+            return channel
+        }
+        set {
+            set(newValue.rawValue, forKey: Keys.updateChannel)
+        }
+    }
+}

--- a/Sources/ClaudeUsageMonitor/Views/Tabs/SettingsTabView.swift
+++ b/Sources/ClaudeUsageMonitor/Views/Tabs/SettingsTabView.swift
@@ -225,6 +225,40 @@ struct SettingsTabView: View {
                     Spacer()
                 }
                 .padding(.bottom, 4)
+                
+                // Update channel selection
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(L10n.Update.updateChannel)
+                        .font(.system(size: 14, weight: .medium))
+                    
+                    ForEach(UpdateChannel.allCases, id: \.self) { channel in
+                        Button(action: {
+                            selectUpdateChannel(channel)
+                        }) {
+                            HStack {
+                                Image(systemName: UserDefaults.standard.updateChannel == channel ? "checkmark.circle.fill" : "circle")
+                                    .foregroundColor(UserDefaults.standard.updateChannel == channel ? .accentColor : .secondary)
+                                    .frame(width: 20)
+                                
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(channel.displayName)
+                                        .font(.system(size: 14, weight: .medium))
+                                    Text(channel.description)
+                                        .font(.system(size: 12))
+                                        .foregroundColor(.secondary)
+                                }
+                                
+                                Spacer()
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(UserDefaults.standard.updateChannel == channel ? Color.accentColor.opacity(0.1) : Color.clear)
+                            .cornerRadius(6)
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                    }
+                }
+                .padding(.bottom, 8)
 
                 // Check for updates button
                 Button(action: {
@@ -291,6 +325,40 @@ struct SettingsTabView: View {
                     Spacer()
                 }
                 .padding(.bottom, 4)
+                
+                // Update channel selection
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(L10n.Update.updateChannel)
+                        .font(.system(size: 14, weight: .medium))
+                    
+                    ForEach(UpdateChannel.allCases, id: \.self) { channel in
+                        Button(action: {
+                            selectUpdateChannel(channel)
+                        }) {
+                            HStack {
+                                Image(systemName: UserDefaults.standard.updateChannel == channel ? "checkmark.circle.fill" : "circle")
+                                    .foregroundColor(UserDefaults.standard.updateChannel == channel ? .accentColor : .secondary)
+                                    .frame(width: 20)
+                                
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(channel.displayName)
+                                        .font(.system(size: 14, weight: .medium))
+                                    Text(channel.description)
+                                        .font(.system(size: 12))
+                                        .foregroundColor(.secondary)
+                                }
+                                
+                                Spacer()
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(UserDefaults.standard.updateChannel == channel ? Color.accentColor.opacity(0.1) : Color.clear)
+                            .cornerRadius(6)
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                    }
+                }
+                .padding(.bottom, 8)
 
                 // Check for updates button
                 Button(action: {
@@ -364,6 +432,15 @@ struct SettingsTabView: View {
             #endif
 
             Spacer()
+        }
+    }
+    
+    private func selectUpdateChannel(_ channel: UpdateChannel) {
+        UserDefaults.standard.updateChannel = channel
+        
+        // Notify AppDelegate to update Sparkle configuration
+        if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+            appDelegate.updateChannelChanged(to: channel)
         }
     }
 }


### PR DESCRIPTION
## Summary
- 安定版（stable）と開発版（dev）のアップデートチャンネルを選択できる機能を追加
- ユーザーが設定画面でチャンネルを切り替えられるようになりました
- dev版ユーザーはdev版のアップデートのみ、stable版ユーザーはstable版のアップデートのみを受け取ります

## Changes
- `UpdateChannel` enumを追加して、stable/devチャンネルを定義
- UserDefaults拡張でチャンネル設定を永続化
- AppDelegateでSparkleのdelegateメソッドを実装し、動的にfeed URLを設定
- 設定画面にチャンネル選択UIを追加（ラジオボタン形式）
- GitHub Actionsを修正して、リリース時に適切なappcast XMLファイルを生成
  - stable版: `appcast.xml`
  - dev版: `appcast-dev.xml`
- 日本語・英語のローカライゼーションを追加

## Test plan
- [ ] Xcodeでビルドして、設定画面でチャンネルが切り替えられることを確認
- [ ] チャンネル切り替え時にSparkleが正しいfeed URLを使用することを確認
- [ ] UserDefaultsにチャンネル設定が保存されることを確認
- [ ] バージョンから自動的に適切なチャンネルが選択されることを確認（-dev付きはdev、それ以外はstable）

🤖 Generated with [Claude Code](https://claude.ai/code)